### PR TITLE
Discard cached objects when files are added

### DIFF
--- a/lib/compliance_engine/ces.rb
+++ b/lib/compliance_engine/ces.rb
@@ -22,15 +22,6 @@ class ComplianceEngine::Ces < ComplianceEngine::Collection
     @by_oval_id
   end
 
-  # Invalidate all cached data
-  #
-  # @param data [ComplianceEngine::Data, NilClass] the data to initialize the object with
-  # @return [NilClass]
-  def invalidate_cache(data = nil)
-    @by_oval_id = nil
-    super
-  end
-
   private
 
   # Returns the key of the collection in compliance engine source data

--- a/lib/compliance_engine/check.rb
+++ b/lib/compliance_engine/check.rb
@@ -35,13 +35,4 @@ class ComplianceEngine::Check < ComplianceEngine::Component
   def remediation
     element['remediation']
   end
-
-  # Invalidate all cached data
-  #
-  # @param data [ComplianceEngine::Data, ComplianceEngine::Collection, NilClass] the data to initialize the object with
-  # @return [NilClass]
-  def invalidate_cache(data = nil)
-    @hiera = nil
-    super
-  end
 end


### PR DESCRIPTION
Also:
    
* Use variable names that do not overlap with method names to avoid confusion
* Use object `instance_variables` method to avoid enumerating variables

Fixes #1