### PR TITLE
Rewrite CLI to use thor gem

### DIFF
--- a/compliance_engine.gemspec
+++ b/compliance_engine.gemspec
@@ -29,9 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # Uncomment to register a new dependency of your gem
   spec.add_dependency 'deep_merge', '~> 1.2'
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency 'thor', '~> 1.3'
 end

--- a/exe/compliance_engine
+++ b/exe/compliance_engine
@@ -3,6 +3,4 @@
 
 require 'compliance_engine/cli'
 
-exitval = ComplianceEngine::CLI.new(ARGV)
-
-exit(exitval) if exitval.is_a?(Integer)
+ComplianceEngine::CLI.start(ARGV)

--- a/lib/compliance_engine/component.rb
+++ b/lib/compliance_engine/component.rb
@@ -157,11 +157,9 @@ class ComplianceEngine::Component
         unless facts.nil?
           fact = facts.dig(*k.split('.'))
           if fact.nil?
-            warn "Fact #{k} not found for #{fragment}"
             return true
           end
           unless fact_match?(fact, v)
-            warn "Fact #{k} #{fact} does not match #{v} for #{fragment}"
             return true
           end
         end

--- a/spec/classes/compliance_engine/cli_spec.rb
+++ b/spec/classes/compliance_engine/cli_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe ComplianceEngine::CLI do
     allow(binding).to receive(:irb).and_return(true)
   end
 
-  xit 'initializes' do
-    pending('TODO: implement mocking of binding.irb')
+  it 'initializes' do
     expect(cli).not_to be_nil
     expect(cli).to be_instance_of(described_class)
   end


### PR DESCRIPTION
* Adds a dependency on `thor`
* Moves the previous default behavior to an `inspect` sub-command
* Adds a `dump` sub-command to dump all of the parsed compliance data
* Adds a `hiera` sub-command to dump all resolved hiera data
* Adds a `lookup` sub-command to get the value of a single hiera key
* Adds options for specifying facts, enforcement tolerance, and paths to modules
* Removes most of the warnings during confinement