### PR TITLE
Add support for confinement based on modules

### DIFF
--- a/compliance_engine.gemspec
+++ b/compliance_engine.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deep_merge', '~> 1.2'
   spec.add_dependency 'thor', '~> 1.3'
+  spec.add_dependency 'semantic_puppet', '~> 1.1'
 end

--- a/lib/compliance_engine/cli.rb
+++ b/lib/compliance_engine/cli.rb
@@ -38,7 +38,7 @@ class ComplianceEngine::CLI < Thor
   def profiles
     data = ComplianceEngine::Data.new(*options[:module], facts: facts, enforcement_tolerance: options[:enforcement_tolerance])
     require 'yaml'
-    puts data.profiles.select { |key, value| value.ces&.count&.positive? || value.controls&.count&.positive? }.keys.to_yaml
+    puts data.profiles.select { |_, value| value.ces&.count&.positive? || value.controls&.count&.positive? }.keys.to_yaml
   end
 
   desc 'inspect', 'Start an interactive shell'

--- a/spec/classes/compliance_engine/check_spec.rb
+++ b/spec/classes/compliance_engine/check_spec.rb
@@ -10,4 +10,113 @@ RSpec.describe ComplianceEngine::Check do
     expect(check).not_to be_nil
     expect(check).to be_instance_of(described_class)
   end
+
+  context 'with data' do
+    let(:test_data) do
+      {
+        'file0' => { 'merge_key' => ['value0'] },
+        'file1' => { 'merge_key' => ['value1'], 'confine' => { 'kernel' => ['Linux'] } },
+        'file2' => { 'merge_key' => ['value2'], 'confine' => { 'kernel' => ['windows'] } },
+        'file3' => { 'merge_key' => ['value3'], 'confine' => { 'module_name' => 'author-module' } },
+        'file4' => { 'merge_key' => ['value4'], 'confine' => { 'module_name' => 'author-module', 'module_version' => '>= 1.0.0 < 2.0.0' } },
+        'file5' => { 'merge_key' => ['value5'], 'remediation' => { 'disabled' => [ { 'reason' => 'anything' } ], 'risk' => [ { 'level' => 1 } ] } },
+        'file6' => { 'merge_key' => ['value6'], 'remediation' => { 'risk' => [ { 'level' => 21 } ] } },
+        'file7' => { 'merge_key' => ['value7'], 'remediation' => { 'risk' => [ { 'level' => 41 } ] } },
+      }
+    end
+
+    before(:each) do
+      test_data.each do |key, value|
+        check.add(key, value)
+      end
+    end
+
+    it 'accepts data' do
+      expect(check.to_a).to be_a(Array)
+      expect(check.to_a.size).to eq test_data.keys.size
+    end
+
+    context 'without confinement' do
+      it 'returns merged data' do
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).to eq(test_data.values.map { |v| v['merge_key'] }.flatten)
+      end
+    end
+
+    context 'with facts' do
+      before(:each) do
+        check.invalidate_cache
+      end
+
+      it 'includes expected values' do
+        check.facts = { 'kernel' => 'Linux' }
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).to include('value0')
+        expect(check.to_h['merge_key']).to include('value1')
+        expect(check.to_h['merge_key']).not_to include('value2')
+      end
+
+      it 'excludes expected values' do
+        check.facts = { 'kernel' => 'Darwin' }
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).to include('value0')
+        expect(check.to_h['merge_key']).not_to include('value1')
+        expect(check.to_h['merge_key']).not_to include('value2')
+      end
+    end
+
+    context 'with environment data' do
+      before(:each) do
+        check.invalidate_cache
+      end
+
+      it 'excludes values based on module name' do
+        check.environment_data = { 'unknown_author-other_module' => '1.0.0' }
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).to include('value0')
+        expect(check.to_h['merge_key']).not_to include('value3')
+        expect(check.to_h['merge_key']).not_to include('value4')
+      end
+
+      it 'includes a value based on module name' do
+        check.environment_data = { 'author-module' => '0.1.0' }
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).to include('value0')
+        expect(check.to_h['merge_key']).to include('value3')
+        expect(check.to_h['merge_key']).not_to include('value4')
+      end
+
+      it 'includes a value based on module name and version' do
+        check.environment_data = { 'author-module' => '1.1.0' }
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).to include('value0')
+        expect(check.to_h['merge_key']).to include('value3')
+        expect(check.to_h['merge_key']).to include('value4')
+      end
+    end
+
+    context 'with enforcement tolerance' do
+      before(:each) do
+        check.invalidate_cache
+      end
+
+      it 'excludes disabled values' do
+        check.enforcement_tolerance = 30
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).not_to include('value5')
+      end
+
+      it 'include values with lower risk' do
+        check.enforcement_tolerance = 30
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).to include('value6')
+      end
+
+      it 'excludes values with higher risk' do
+        check.enforcement_tolerance = 30
+        expect(check.to_h).to be_a(Hash)
+        expect(check.to_h['merge_key']).not_to include('value7')
+      end
+    end
+  end
 end

--- a/spec/classes/compliance_engine/component_spec.rb
+++ b/spec/classes/compliance_engine/component_spec.rb
@@ -10,4 +10,86 @@ RSpec.describe ComplianceEngine::Component do
     expect(component).not_to be_nil
     expect(component).to be_instance_of(described_class)
   end
+
+  context 'with data' do
+    let(:test_data) do
+      {
+        'file0' => { 'merge_key' => ['value0'] },
+        'file1' => { 'merge_key' => ['value1'], 'confine' => { 'kernel' => ['Linux'] } },
+        'file2' => { 'merge_key' => ['value2'], 'confine' => { 'kernel' => ['windows'] } },
+        'file3' => { 'merge_key' => ['value3'], 'confine' => { 'module_name' => 'author-module' } },
+        'file4' => { 'merge_key' => ['value4'], 'confine' => { 'module_name' => 'author-module', 'module_version' => '>= 1.0.0 < 2.0.0' } },
+      }
+    end
+
+    before(:each) do
+      test_data.each do |key, value|
+        component.add(key, value)
+      end
+    end
+
+    it 'accepts data' do
+      expect(component.to_a).to be_a(Array)
+      expect(component.to_a.size).to eq test_data.keys.size
+    end
+
+    context 'without confinement' do
+      it 'returns merged data' do
+        expect(component.to_h).to be_a(Hash)
+        expect(component.to_h['merge_key']).to eq(test_data.values.map { |v| v['merge_key'] }.flatten)
+      end
+    end
+
+    context 'with facts' do
+      before(:each) do
+        component.invalidate_cache
+      end
+
+      it 'includes expected values' do
+        component.facts = { 'kernel' => 'Linux' }
+        expect(component.to_h).to be_a(Hash)
+        expect(component.to_h['merge_key']).to include('value0')
+        expect(component.to_h['merge_key']).to include('value1')
+        expect(component.to_h['merge_key']).not_to include('value2')
+      end
+
+      it 'excludes expected values' do
+        component.facts = { 'kernel' => 'Darwin' }
+        expect(component.to_h).to be_a(Hash)
+        expect(component.to_h['merge_key']).to include('value0')
+        expect(component.to_h['merge_key']).not_to include('value1')
+        expect(component.to_h['merge_key']).not_to include('value2')
+      end
+    end
+
+    context 'with environment data' do
+      before(:each) do
+        component.invalidate_cache
+      end
+
+      it 'excludes values based on module name' do
+        component.environment_data = { 'unknown_author-other_module' => '1.0.0' }
+        expect(component.to_h).to be_a(Hash)
+        expect(component.to_h['merge_key']).to include('value0')
+        expect(component.to_h['merge_key']).not_to include('value3')
+        expect(component.to_h['merge_key']).not_to include('value4')
+      end
+
+      it 'includes a value based on module name' do
+        component.environment_data = { 'author-module' => '0.1.0' }
+        expect(component.to_h).to be_a(Hash)
+        expect(component.to_h['merge_key']).to include('value0')
+        expect(component.to_h['merge_key']).to include('value3')
+        expect(component.to_h['merge_key']).not_to include('value4')
+      end
+
+      it 'includes a value based on module name and version' do
+        component.environment_data = { 'author-module' => '1.1.0' }
+        expect(component.to_h).to be_a(Hash)
+        expect(component.to_h['merge_key']).to include('value0')
+        expect(component.to_h['merge_key']).to include('value3')
+        expect(component.to_h['merge_key']).to include('value4')
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Load metadata for modules as they are scanned
* Add support for `confine` keys `module_name` and `module_version`
* Implement component `to_h` method
* Add rspec tests for components and checks
* Fix a rubocop warning