### PR TITLE
chore: Add AGENTS.md to .pdkignore

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -58,3 +58,4 @@
 /renovate.json
 /exe/
 /*.gemspec
+/AGENTS.md


### PR DESCRIPTION
We do not need to include `AGENTS.md` in the Forge module artifact.