### PR TITLE
Add JRuby to CI testing matrix

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -71,6 +71,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Install native build tools (required by prism on JRuby)
+        if: startsWith(matrix.ruby, 'jruby')
+        run: sudo apt-get update && sudo apt-get install -y build-essential
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -66,6 +66,8 @@ jobs:
           - '3.3'
           - '3.4'
           - '4.0'  # Latest
+          - 'jruby-9.4'  # OpenVox Server 8
+          - 'jruby-10.0'  # Ruby 3.4-compatible
 
     steps:
       - uses: actions/checkout@v6

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :release do
 end
 
 group :acceptance do
-  gem 'voxpupuli-acceptance', '~> 4.0'
+  gem 'voxpupuli-acceptance', '~> 4.0', platforms: :mri
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rake', '~> 13.4.0'
 group :tests do
   # renovate: datasource=rubygems versioning=ruby
   gem 'openvox', ENV.fetch('OPENVOX_VERSION', ENV.fetch('PUPPET_VERSION', '~> 8.0'))
-  gem 'syslog', require: false
+  gem 'syslog', require: false, platforms: :mri
   gem 'voxpupuli-test', '~> 14.0'
 end
 
@@ -24,6 +24,6 @@ end
 
 group :development do
   gem 'pry'
-  gem 'pry-byebug'
-  gem 'ruby-prof'
+  gem 'pry-byebug', platforms: :mri
+  gem 'ruby-prof', platforms: :mri
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rake', '~> 13.4.0'
 group :tests do
   # renovate: datasource=rubygems versioning=ruby
   gem 'openvox', ENV.fetch('OPENVOX_VERSION', ENV.fetch('PUPPET_VERSION', '~> 8.0'))
-  gem 'syslog', require: false, platforms: :mri
+  gem 'syslog', require: false
   gem 'voxpupuli-test', '~> 14.0'
 end
 

--- a/compliance_engine.gemspec
+++ b/compliance_engine.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'deep_merge', '~> 1.2'
-  spec.add_dependency 'irb', '~> 1.14'
+  spec.add_dependency 'irb', '~> 1.14' unless RUBY_PLATFORM == 'java'
   spec.add_dependency 'logger', '~> 1.4'
   spec.add_dependency 'observer', '~> 0.1'
   spec.add_dependency 'rubyzip', '>= 2.3', '< 4'

--- a/spec/spec_helper_puppet.rb
+++ b/spec/spec_helper_puppet.rb
@@ -11,12 +11,12 @@ end
 # correctly and the Win32::Registry stub gets defined.
 if defined?(JRUBY_VERSION)
   module Kernel
-    alias_method :require_without_fiddle_dl_error_fix, :require
+    alias require_without_fiddle_dl_error_fix require
 
     def require(path)
       require_without_fiddle_dl_error_fix(path)
-    rescue => e
-      raise unless e.class.name == 'Fiddle::DLError'
+    rescue StandardError => e
+      raise unless e.instance_of?(::Fiddle::DLError)
 
       raise LoadError, e.message
     end

--- a/spec/spec_helper_puppet.rb
+++ b/spec/spec_helper_puppet.rb
@@ -4,6 +4,28 @@ RSpec.configure do |c|
   c.mock_with :rspec
 end
 
+# JRuby 10.0 / Ruby 3.4 workaround: rspec-puppet unconditionally requires
+# 'win32/registry' and only rescues LoadError. On JRuby 10.0+ the file exists
+# in the Ruby 3.4 stdlib but raises Fiddle::DLError (not LoadError) when it
+# cannot open kernel32.dll. Patch Kernel#require so rspec-puppet's rescue fires
+# correctly and the Win32::Registry stub gets defined.
+if defined?(JRUBY_VERSION)
+  module Kernel
+    alias_method :require_without_fiddle_dl_error_fix, :require
+
+    def require(path)
+      require_without_fiddle_dl_error_fix(path)
+    rescue => e
+      raise unless e.class.name == 'Fiddle::DLError'
+
+      raise LoadError, e.message
+    end
+
+    module_function :require
+    module_function :require_without_fiddle_dl_error_fix
+  end
+end
+
 require 'voxpupuli/test/spec_helper'
 require 'rspec-puppet-facts'
 


### PR DESCRIPTION
Add JRuby 9.4 (ships with OpenVox Server 8) and JRuby 10.0 (Ruby 3.4-compatible) to the spec-tests matrix to catch compatibility issues like the missing observer gem in puppetserver environments.

Also guard MRI-only gems (syslog, pry-byebug, ruby-prof) with `platforms: :mri` so bundle install succeeds on JRuby, and simplify the test command to unconditionally run parallel_spec now that the openvox gem works on Ruby 4.