### PR TITLE
Replace pdk with puppet-modulebuilder for Forge builds

### DIFF
--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -229,11 +229,12 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          # PDK requires pinning to Ruby < 4.0
-          ruby-version: 3.4.9
+          ruby-version: 4.0.2
           bundler-cache: true
-      - name: Build Puppet module (PDK)
-        run: bundle exec pdk build --force
+        env:
+          BUNDLE_WITH: release
+      - name: Build Puppet module
+        run: bundle exec rake module:build
       - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
           curl -X POST --silent --show-error --fail \

--- a/Gemfile
+++ b/Gemfile
@@ -2,19 +2,20 @@
 
 source 'https://rubygems.org'
 
-ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
-
 # Specify your gem's dependencies in compliance_engine.gemspec
 gemspec
 
 gem 'rake', '~> 13.4.0'
 
 group :tests do
-  gem 'openvox', ENV.fetch('OPENVOX_VERSION', ENV.fetch('PUPPET_VERSION', '~> 8.0'))
   # renovate: datasource=rubygems versioning=ruby
-  gem 'pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false if RUBY_VERSION < '4'
+  gem 'openvox', ENV.fetch('OPENVOX_VERSION', ENV.fetch('PUPPET_VERSION', '~> 8.0'))
   gem 'syslog', require: false
   gem 'voxpupuli-test', '~> 13.0'
+end
+
+group :release do
+  gem 'puppet-modulebuilder', '~> 2.0', require: false
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -24,3 +24,37 @@ task spec: :'fixtures:prep' do |_t, args|
 end
 
 task default: [:spec, :rubocop]
+
+# Puppet module build (requires `bundle install` with the release group).
+#
+# puppet-modulebuilder 2.x dropped support for .pdkignore; this subclass
+# restores it so the published module package matches what PDK produced.
+begin
+  require 'puppet/modulebuilder'
+
+  class PdkCompatBuilder < Puppet::Modulebuilder::Builder
+    def ignored_files
+      spec = super
+      pdkignore = File.join(source, '.pdkignore')
+      return spec unless File.exist?(pdkignore)
+
+      File.readlines(pdkignore, chomp: true).each do |line|
+        next if line.strip.empty? || line.start_with?('#')
+
+        spec.add(line)
+      end
+      spec
+    end
+  end
+
+  namespace :module do
+    desc 'Build the Puppet module package into pkg/, honouring .pdkignore'
+    task :build do
+      builder = PdkCompatBuilder.new(Dir.pwd)
+      pkg = builder.build
+      puts "Built: #{pkg}"
+    end
+  end
+rescue LoadError
+  # puppet-modulebuilder not installed; run `bundle install` with the release group
+end


### PR DESCRIPTION
puppet-modulebuilder 2.x dropped .pdkignore support, so add a PdkCompatBuilder subclass in the Rakefile that overrides ignored_files to read .pdkignore patterns (if the file exists) on top of the built-in IGNORED list.  The new module:build Rake task uses this class.

The tag_deploy_rubygem.yml deploy-to-puppet-forge job now runs `bundle exec rake module:build` instead of `bundle exec pdk build --force`, and can use Ruby 4.0.2 (no longer pinned to < 4.0).