### PR TITLE
Split version.rb: separate gem VERSION from data format validator

### DIFF
--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../compliance_engine'
-require_relative 'version'
+require_relative 'data_version'
 require_relative 'component'
 require_relative 'ce'
 require_relative 'check'
@@ -221,7 +221,7 @@ class ComplianceEngine::Data
       loader.add_observer(self, :update)
       data[key] = {
         loader: loader,
-        version: ComplianceEngine::Version.new(loader.data['version']),
+        version: ComplianceEngine::DataVersion.new(loader.data['version']),
         content: loader.data,
       }
     else
@@ -237,7 +237,7 @@ class ComplianceEngine::Data
         data[filename.key][:loader] = filename
         data[filename.key][:loader].add_observer(self, :update)
       end
-      data[filename.key][:version] = ComplianceEngine::Version.new(filename.data['version'])
+      data[filename.key][:version] = ComplianceEngine::DataVersion.new(filename.data['version'])
       data[filename.key][:content] = filename.data
     end
 

--- a/lib/compliance_engine/data_version.rb
+++ b/lib/compliance_engine/data_version.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require_relative '../compliance_engine'
+
 module ComplianceEngine
   # Validates the version field found in compliance data files.
   # Currently only version 2.0.0 of the data format is supported.
   class DataVersion
     def initialize(version)
-      raise 'Missing version' if version.nil?
-      raise "Unsupported version '#{version}'" unless version == '2.0.0'
+      raise ComplianceEngine::Error, 'Missing version' if version.nil?
+      raise ComplianceEngine::Error, "Unsupported version '#{version}'" unless version == '2.0.0'
 
       @version = version
     end

--- a/lib/compliance_engine/data_version.rb
+++ b/lib/compliance_engine/data_version.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ComplianceEngine
+  # Validates the version field found in compliance data files.
+  # Currently only version 2.0.0 of the data format is supported.
+  class DataVersion
+    def initialize(version)
+      raise 'Missing version' if version.nil?
+      raise "Unsupported version '#{version}'" unless version == '2.0.0'
+
+      @version = version
+    end
+
+    # @return [String]
+    def to_s
+      @version
+    end
+  end
+end

--- a/lib/compliance_engine/data_version.rb
+++ b/lib/compliance_engine/data_version.rb
@@ -6,6 +6,8 @@ module ComplianceEngine
   # Validates the version field found in compliance data files.
   # Currently only version 2.0.0 of the data format is supported.
   class DataVersion
+    # @param version [String] the version string from a compliance data file
+    # @raise [ComplianceEngine::Error] if version is nil or not '2.0.0'
     def initialize(version)
       raise ComplianceEngine::Error, 'Missing version' if version.nil?
       raise ComplianceEngine::Error, "Unsupported version '#{version}'" unless version == '2.0.0'

--- a/lib/compliance_engine/data_version.rb
+++ b/lib/compliance_engine/data_version.rb
@@ -2,22 +2,20 @@
 
 require_relative '../compliance_engine'
 
-module ComplianceEngine
-  # Validates the version field found in compliance data files.
-  # Currently only version 2.0.0 of the data format is supported.
-  class DataVersion
-    # @param version [String] the version string from a compliance data file
-    # @raise [ComplianceEngine::Error] if version is nil or not '2.0.0'
-    def initialize(version)
-      raise ComplianceEngine::Error, 'Missing version' if version.nil?
-      raise ComplianceEngine::Error, "Unsupported version '#{version}'" unless version == '2.0.0'
+# Validates the version field found in compliance data files.
+# Currently only version 2.0.0 of the data format is supported.
+class ComplianceEngine::DataVersion
+  # @param version [String] the version string from a compliance data file
+  # @raise [ComplianceEngine::Error] if version is nil or not '2.0.0'
+  def initialize(version)
+    raise ComplianceEngine::Error, 'Missing version' if version.nil?
+    raise ComplianceEngine::Error, "Unsupported version '#{version}'" unless version == '2.0.0'
 
-      @version = version
-    end
+    @version = version
+  end
 
-    # @return [String]
-    def to_s
-      @version
-    end
+  # @return [String]
+  def to_s
+    @version
   end
 end

--- a/lib/compliance_engine/version.rb
+++ b/lib/compliance_engine/version.rb
@@ -2,24 +2,4 @@
 
 module ComplianceEngine
   VERSION = '0.4.0'
-
-  # Handle supported compliance data versions
-  class Version
-    # Verify that the version is supported
-    #
-    # @param version [String] The version to verify
-    def initialize(version)
-      raise 'Missing version' if version.nil?
-      raise "Unsupported version '#{version}'" unless version == '2.0.0'
-
-      @version = version
-    end
-
-    # Convert the version to a string
-    #
-    # @return [String]
-    def to_s
-      @version
-    end
-  end
 end

--- a/spec/classes/compliance_engine/data_version_spec.rb
+++ b/spec/classes/compliance_engine/data_version_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'compliance_engine'
 
-RSpec.describe ComplianceEngine::Version do
+RSpec.describe ComplianceEngine::DataVersion do
   context 'with a valid version number' do
     subject(:version) { described_class.new('2.0.0') }
 

--- a/spec/classes/compliance_engine/data_version_spec.rb
+++ b/spec/classes/compliance_engine/data_version_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ComplianceEngine::DataVersion do
     subject(:version) { described_class.new('1.0') }
 
     it 'fails to initialize' do
-      expect { version }.to raise_error(StandardError, %r{Unsupported version})
+      expect { version }.to raise_error(ComplianceEngine::Error, %r{Unsupported version})
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe ComplianceEngine::DataVersion do
     subject(:version) { described_class.new(nil) }
 
     it 'fails to initialize' do
-      expect { version }.to raise_error(StandardError, %r{Missing version})
+      expect { version }.to raise_error(ComplianceEngine::Error, %r{Missing version})
     end
   end
 end


### PR DESCRIPTION
ComplianceEngine::VERSION (gem release version) and the compliance data format version validator were unrelated but sharing a file. Extract the validator into ComplianceEngine::DataVersion in data_version.rb, leaving version.rb with only the VERSION constant.