### PR TITLE
Add ComplianceEngine::Tolerance constants for enforcement tolerance levels

### DIFF
--- a/lib/compliance_engine.rb
+++ b/lib/compliance_engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'compliance_engine/version'
+require_relative 'compliance_engine/tolerance'
 require_relative 'compliance_engine/data'
 require 'logger'
 

--- a/lib/compliance_engine/tolerance.rb
+++ b/lib/compliance_engine/tolerance.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ComplianceEngine
+  # Named constants for enforcement tolerance levels.
+  #
+  # The enforcement tolerance controls which remediation risk levels are
+  # enforced. A check whose risk level is greater than or equal to the
+  # tolerance value is filtered out. For example, setting
+  # +enforcement_tolerance+ to +ComplianceEngine::Tolerance::MODERATE+
+  # enforces checks with risk levels below 60 while skipping anything
+  # rated MODERATE (60) or higher.
+  module Tolerance
+    # Enforce only checks with no meaningful risk (risk < 20).
+    NONE = 20
+
+    # Enforce checks up to and including low-risk remediations (risk < 40).
+    SAFE = 40
+
+    # Enforce checks up to and including moderate-risk remediations (risk < 60).
+    MODERATE = 60
+
+    # Enforce checks up to and including remediations that affect access (risk < 80).
+    ACCESS = 80
+
+    # Enforce all checks, including those that may cause breaking changes (risk < 100).
+    BREAKING = 100
+  end
+end

--- a/lib/compliance_engine/tolerance.rb
+++ b/lib/compliance_engine/tolerance.rb
@@ -13,13 +13,13 @@ module ComplianceEngine
     # Enforce only checks with no meaningful risk (risk < 20).
     NONE = 20
 
-    # Enforce checks up to and including low-risk remediations (risk < 40).
+    # Enforce checks below low-risk remediations; skip SAFE (40) and above (risk < 40).
     SAFE = 40
 
-    # Enforce checks up to and including moderate-risk remediations (risk < 60).
+    # Enforce checks below moderate-risk remediations; skip MODERATE (60) and above (risk < 60).
     MODERATE = 60
 
-    # Enforce checks up to and including remediations that affect access (risk < 80).
+    # Enforce checks below remediations that affect access; skip ACCESS (80) and above (risk < 80).
     ACCESS = 80
 
     # Enforce all checks, including those that may cause breaking changes (risk < 100).

--- a/spec/classes/compliance_engine/tolerance_spec.rb
+++ b/spec/classes/compliance_engine/tolerance_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'compliance_engine'
+
+RSpec.describe ComplianceEngine::Tolerance do
+  it { expect(described_class::NONE).to eq(20) }
+  it { expect(described_class::SAFE).to eq(40) }
+  it { expect(described_class::MODERATE).to eq(60) }
+  it { expect(described_class::ACCESS).to eq(80) }
+  it { expect(described_class::BREAKING).to eq(100) }
+
+  it 'has constants in ascending order' do
+    levels = [
+      described_class::NONE,
+      described_class::SAFE,
+      described_class::MODERATE,
+      described_class::ACCESS,
+      described_class::BREAKING,
+    ]
+    expect(levels).to eq(levels.sort)
+  end
+end


### PR DESCRIPTION
Introduces ComplianceEngine::Tolerance with named constants (NONE, SAFE, MODERATE, ACCESS, BREAKING) so callers can refer to risk thresholds descriptively rather than using bare integers.

Fixes #12