### PR TITLE
Drop stale file data on rescan and add data update tests

### DIFF
--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -161,9 +161,16 @@ class ComplianceEngine::Data
 
       if path.is_a?(ComplianceEngine::ModuleLoader)
         modules[path.name] = path.version unless path.name.nil?
-        path.files.each do |file_loader|
-          update(file_loader)
-        end
+        new_keys = path.files.to_set(&:key)
+        module_prefix = if path.zipfile_path
+                          ::File.join(path.zipfile_path, '.', path.path)
+                        else
+                          path.path
+                        end
+        stale_keys = data.keys.select { |k| k.start_with?(module_prefix) && !new_keys.include?(k) }
+        stale_keys.each { |k| data.delete(k) }
+        path.files.each { |file_loader| update(file_loader) }
+        reset_collection unless stale_keys.empty?
         next
       end
 

--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -172,7 +172,7 @@ class ComplianceEngine::Data
         stale_keys = data.keys.select { |k| (k == module_root || k.start_with?(module_prefix)) && !new_keys.include?(k) }
         stale_keys.each { |k| data.delete(k) }
         path.files.each { |file_loader| update(file_loader) }
-        reset_collection unless stale_keys.empty?
+        reset_collection if path.files.empty? && !stale_keys.empty?
         next
       end
 

--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'set'
 require_relative '../compliance_engine'
 require_relative 'data_version'
 require_relative 'component'
@@ -162,12 +163,13 @@ class ComplianceEngine::Data
       if path.is_a?(ComplianceEngine::ModuleLoader)
         modules[path.name] = path.version unless path.name.nil?
         new_keys = path.files.to_set(&:key)
-        module_prefix = if path.zipfile_path
-                          ::File.join(path.zipfile_path, '.', path.path)
-                        else
-                          path.path
-                        end
-        stale_keys = data.keys.select { |k| k.start_with?(module_prefix) && !new_keys.include?(k) }
+        module_root = if path.zipfile_path
+                        ::File.join(path.zipfile_path, '.', path.path)
+                      else
+                        path.path
+                      end
+        module_prefix = ::File.join(module_root, '')
+        stale_keys = data.keys.select { |k| (k == module_root || k.start_with?(module_prefix)) && !new_keys.include?(k) }
         stale_keys.each { |k| data.delete(k) }
         path.files.each { |file_loader| update(file_loader) }
         reset_collection unless stale_keys.empty?

--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -164,7 +164,7 @@ class ComplianceEngine::Data
         modules[path.name] = path.version unless path.name.nil?
         new_keys = path.files.to_set(&:key)
         module_root = if path.zipfile_path
-                        ::File.join(path.zipfile_path, '.', path.path)
+                        ::File.join(path.zipfile_path, '.', path.path.sub(%r{^/+}, ''))
                       else
                         path.path
                       end

--- a/lib/compliance_engine/module_loader.rb
+++ b/lib/compliance_engine/module_loader.rb
@@ -18,6 +18,7 @@ class ComplianceEngine::ModuleLoader
     @name = nil
     @version = nil
     @files = []
+    @path = path.to_s
     @zipfile_path = zipfile_path
 
     # Read the Puppet module's metadata.json
@@ -59,5 +60,5 @@ class ComplianceEngine::ModuleLoader
     end
   end
 
-  attr_reader :name, :version, :files, :zipfile_path
+  attr_reader :name, :version, :files, :path, :zipfile_path
 end

--- a/lib/compliance_engine/module_loader.rb
+++ b/lib/compliance_engine/module_loader.rb
@@ -23,6 +23,7 @@ class ComplianceEngine::ModuleLoader
     @name = nil
     @version = nil
     @files = []
+    @path = path.to_s
     @zipfile_path = zipfile_path
 
     # Read the Puppet module's metadata.json
@@ -76,5 +77,5 @@ class ComplianceEngine::ModuleLoader
     end
   end
 
-  attr_reader :name, :version, :files, :zipfile_path
+  attr_reader :name, :version, :files, :path, :zipfile_path
 end

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1149,4 +1149,118 @@ RSpec.describe ComplianceEngine::Data do
       expect(compliance_engine.ces.keys).to eq(['ce_00', 'ce_01', 'ce_02', 'ce_03'])
     end
   end
+
+  context 'data updates' do
+    subject(:compliance_engine) { described_class.new }
+
+    let(:module_path) { 'update_test_module' }
+    let(:compliance_dir) { "#{module_path}/SIMP/compliance_profiles" }
+    let(:file_a_path) { "#{compliance_dir}/a.yaml" }
+    let(:file_b_path) { "#{compliance_dir}/b.yaml" }
+
+    let(:file_a_contents) do
+      <<~YAML
+        ---
+        version: 2.0.0
+        profiles:
+          profile_a:
+            ces:
+              ce_a: true
+        ce:
+          ce_a:
+            controls:
+              control_a: true
+        checks:
+          check_a:
+            type: puppet-class-parameter
+            settings:
+              parameter: mymodule::param_a
+              value: value_a
+            ces:
+              - ce_a
+      YAML
+    end
+
+    let(:file_b_contents) do
+      <<~YAML
+        ---
+        version: 2.0.0
+        profiles:
+          profile_b:
+            ces:
+              ce_b: true
+        ce:
+          ce_b:
+            controls:
+              control_b: true
+        checks:
+          check_b:
+            type: puppet-class-parameter
+            settings:
+              parameter: mymodule::param_b
+              value: value_b
+            ces:
+              - ce_b
+      YAML
+    end
+
+    def stub_module(glob_results)
+      allow(File).to receive(:directory?).with(module_path).and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/SIMP/compliance_profiles").and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/simp/compliance_profiles").and_return(false)
+      allow(Dir).to receive(:glob).with("#{compliance_dir}/**/*.yaml").and_return(*glob_results)
+      allow(Dir).to receive(:glob).with("#{compliance_dir}/**/*.json").and_return([])
+
+      [[file_a_path, file_a_contents], [file_b_path, file_b_contents]].each do |path, contents|
+        allow(File).to receive(:size).with(path).and_return(contents.length)
+        allow(File).to receive(:mtime).with(path).and_return(Time.now)
+        allow(File).to receive(:read).with(path).and_return(contents)
+      end
+    end
+
+    context 'when a new file is added between scans' do
+      before(:each) { stub_module([[file_a_path], [file_a_path, file_b_path]]) }
+
+      it 'picks up the new profile on re-scan' do
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a')
+        expect(compliance_engine.files).to contain_exactly(file_a_path)
+        expect(compliance_engine.hiera(['profile_a'])).to eq({ 'mymodule::param_a' => 'value_a' })
+
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+        expect(compliance_engine.files).to contain_exactly(file_a_path, file_b_path)
+        expect(compliance_engine.hiera(['profile_b'])).to eq({ 'mymodule::param_b' => 'value_b' })
+      end
+    end
+
+    context 'when a file is deleted between scans' do
+      before(:each) { stub_module([[file_a_path, file_b_path], [file_a_path]]) }
+
+      it 'drops data from the deleted file on re-scan' do
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+        expect(compliance_engine.files).to contain_exactly(file_a_path, file_b_path)
+        expect(compliance_engine.hiera(['profile_b'])).to eq({ 'mymodule::param_b' => 'value_b' })
+
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a')
+        expect(compliance_engine.files).to contain_exactly(file_a_path)
+        expect(compliance_engine.hiera(['profile_b'])).to eq({})
+      end
+    end
+
+    context 'when all files in a module are deleted between scans' do
+      before(:each) { stub_module([[file_a_path, file_b_path], []]) }
+
+      it 'drops all module data on re-scan' do
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to be_empty
+        expect(compliance_engine.files).to be_empty
+      end
+    end
+  end
 end

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1625,4 +1625,122 @@ RSpec.describe ComplianceEngine::Data do
       end
     end
   end
+
+  context 'data updates' do
+    subject(:compliance_engine) { described_class.new }
+
+    let(:module_path) { 'update_test_module' }
+    let(:compliance_dir) { "#{module_path}/SIMP/compliance_profiles" }
+    let(:file_a_path) { "#{compliance_dir}/a.yaml" }
+    let(:file_b_path) { "#{compliance_dir}/b.yaml" }
+
+    let(:file_a_contents) do
+      <<~YAML
+        ---
+        version: 2.0.0
+        profiles:
+          profile_a:
+            ces:
+              ce_a: true
+        ce:
+          ce_a:
+            controls:
+              control_a: true
+        checks:
+          check_a:
+            type: puppet-class-parameter
+            settings:
+              parameter: mymodule::param_a
+              value: value_a
+            ces:
+              - ce_a
+      YAML
+    end
+
+    let(:file_b_contents) do
+      <<~YAML
+        ---
+        version: 2.0.0
+        profiles:
+          profile_b:
+            ces:
+              ce_b: true
+        ce:
+          ce_b:
+            controls:
+              control_b: true
+        checks:
+          check_b:
+            type: puppet-class-parameter
+            settings:
+              parameter: mymodule::param_b
+              value: value_b
+            ces:
+              - ce_b
+      YAML
+    end
+
+    def stub_module(glob_results)
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:exist?).and_call_original
+      allow(Dir).to receive(:glob).and_call_original
+      allow(File).to receive(:directory?).with(module_path).and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/SIMP/compliance_profiles").and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/simp/compliance_profiles").and_return(false)
+      allow(File).to receive(:exist?).with("#{module_path}/metadata.json").and_return(false)
+      allow(Dir).to receive(:glob).with("#{compliance_dir}/**/*.yaml").and_return(*glob_results)
+      allow(Dir).to receive(:glob).with("#{compliance_dir}/**/*.json").and_return([])
+
+      [[file_a_path, file_a_contents], [file_b_path, file_b_contents]].each do |path, contents|
+        allow(File).to receive(:size).with(path).and_return(contents.length)
+        allow(File).to receive(:mtime).with(path).and_return(Time.now)
+        allow(File).to receive(:read).with(path).and_return(contents)
+      end
+    end
+
+    context 'when a new file is added between scans' do
+      before(:each) { stub_module([[file_a_path], [file_a_path, file_b_path]]) }
+
+      it 'picks up the new profile on re-scan' do
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a')
+        expect(compliance_engine.files).to contain_exactly(file_a_path)
+        expect(compliance_engine.hiera(['profile_a'])).to eq({ 'mymodule::param_a' => 'value_a' })
+
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+        expect(compliance_engine.files).to contain_exactly(file_a_path, file_b_path)
+        expect(compliance_engine.hiera(['profile_b'])).to eq({ 'mymodule::param_b' => 'value_b' })
+      end
+    end
+
+    context 'when a file is deleted between scans' do
+      before(:each) { stub_module([[file_a_path, file_b_path], [file_a_path]]) }
+
+      it 'drops data from the deleted file on re-scan' do
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+        expect(compliance_engine.files).to contain_exactly(file_a_path, file_b_path)
+        expect(compliance_engine.hiera(['profile_b'])).to eq({ 'mymodule::param_b' => 'value_b' })
+
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a')
+        expect(compliance_engine.files).to contain_exactly(file_a_path)
+        expect(compliance_engine.hiera(['profile_b'])).to eq({})
+      end
+    end
+
+    context 'when all files in a module are deleted between scans' do
+      before(:each) { stub_module([[file_a_path, file_b_path], []]) }
+
+      it 'drops all module data on re-scan' do
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+
+        compliance_engine.open(module_path)
+        expect(compliance_engine.profiles.keys).to be_empty
+        expect(compliance_engine.files).to be_empty
+      end
+    end
+  end
 end

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1743,4 +1743,108 @@ RSpec.describe ComplianceEngine::Data do
       end
     end
   end
+
+  context 'zip data updates' do
+    subject(:compliance_engine) { described_class.new }
+
+    let(:zip_path) { 'test_env.zip' }
+    let(:module_path) { '/zip_test_module' }
+    let(:compliance_dir) { "#{module_path}/SIMP/compliance_profiles" }
+    let(:file_a_path) { "#{compliance_dir}/a.yaml" }
+    let(:file_b_path) { "#{compliance_dir}/b.yaml" }
+
+    let(:file_a_contents) do
+      <<~YAML
+        ---
+        version: 2.0.0
+        profiles:
+          profile_a:
+            ces:
+              ce_a: true
+        ce:
+          ce_a:
+            controls:
+              control_a: true
+        checks:
+          check_a:
+            type: puppet-class-parameter
+            settings:
+              parameter: mymodule::param_a
+              value: value_a
+            ces:
+              - ce_a
+      YAML
+    end
+
+    let(:file_b_contents) do
+      <<~YAML
+        ---
+        version: 2.0.0
+        profiles:
+          profile_b:
+            ces:
+              ce_b: true
+        ce:
+          ce_b:
+            controls:
+              control_b: true
+        checks:
+          check_b:
+            type: puppet-class-parameter
+            settings:
+              parameter: mymodule::param_b
+              value: value_b
+            ces:
+              - ce_b
+      YAML
+    end
+
+    def make_zip_loaders(first_glob, second_glob)
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:exist?).and_call_original
+      allow(Dir).to receive(:glob).and_call_original
+      allow(File).to receive(:directory?).with(module_path).and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/SIMP/compliance_profiles").and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/simp/compliance_profiles").and_return(false)
+      allow(File).to receive(:exist?).with("#{module_path}/metadata.json").and_return(false)
+      allow(Dir).to receive(:glob).with("#{compliance_dir}/**/*.yaml").and_return(first_glob, second_glob)
+      allow(Dir).to receive(:glob).with("#{compliance_dir}/**/*.json").and_return([])
+
+      [[file_a_path, file_a_contents], [file_b_path, file_b_contents]].each do |path, contents|
+        allow(File).to receive(:size).with(path).and_return(contents.length)
+        allow(File).to receive(:mtime).with(path).and_return(Time.now)
+        allow(File).to receive(:read).with(path).and_return(contents)
+      end
+
+      first = ComplianceEngine::ModuleLoader.new(module_path, zipfile_path: zip_path)
+      second = ComplianceEngine::ModuleLoader.new(module_path, zipfile_path: zip_path)
+      [first, second]
+    end
+
+    context 'when a file is deleted between scans' do
+      it 'drops data from the deleted file on re-scan' do
+        first_loader, second_loader = make_zip_loaders([file_a_path, file_b_path], [file_a_path])
+
+        compliance_engine.open(first_loader)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+
+        compliance_engine.open(second_loader)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a')
+        expect(compliance_engine.hiera(['profile_b'])).to eq({})
+      end
+    end
+
+    context 'when all files in a zip module are deleted between scans' do
+      it 'drops all module data on re-scan' do
+        first_loader, second_loader = make_zip_loaders([file_a_path, file_b_path], [])
+
+        compliance_engine.open(first_loader)
+        expect(compliance_engine.profiles.keys).to contain_exactly('profile_a', 'profile_b')
+
+        compliance_engine.open(second_loader)
+        expect(compliance_engine.profiles.keys).to be_empty
+        expect(compliance_engine.files).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
When open() is called again with the same module path, files that no longer exist on disk were left behind in the internal data hash.  Fix this by exposing the module directory path from ModuleLoader and using it in Data#open to compute the set of stale keys (present in data but absent from the new scan) and delete them before processing current files.

Adds three new data-update tests covering: new file added between scans, file deleted between scans, and all module files deleted.

- Fixes #19
- Fixes #20