### PR TITLE
feat: support compliance_markup-style parameter knockout

### DIFF
--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -306,7 +306,7 @@ class ComplianceEngine::Data
         v.to_a.each do |component|
           next unless component.key?('confine')
 
-          @confines = DeepMerge.deep_merge!(component['confine'], @confines)
+          @confines = DeepMerge.deep_merge!(Marshal.load(Marshal.dump(component['confine'])), @confines, knockout_prefix: '--')
         end
       end
     end
@@ -348,8 +348,22 @@ class ComplianceEngine::Data
 
     valid_profiles.reverse_each do |profile|
       check_mapping(profile).each_value do |check|
-        parameters = DeepMerge.deep_merge!(check.hiera, parameters)
+        hiera_data = check.hiera
+        next if hiera_data.nil?
+
+        parameters = DeepMerge.deep_merge!(Marshal.load(Marshal.dump(hiera_data)), parameters)
       end
+    end
+
+    # deep_merge does not support hash-key knockout via knockout_prefix.
+    # Handle parameter-name knockout explicitly: any key starting with '--'
+    # signals that the matching key without the prefix should be suppressed
+    # (mirrors compliance_markup behavior).
+    parameters.each_key do |key|
+      next unless key.start_with?('--')
+
+      parameters.delete(key.delete_prefix('--'))
+      parameters.delete(key)
     end
 
     @hiera[cache_key] = parameters

--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -306,8 +306,8 @@ class ComplianceEngine::Data
         v.to_a.each do |component|
           next unless component.key?('confine')
 
-          confine = component['confine'].transform_values { |val| val.is_a?(Array) ? val : Array(val) }
-          @confines = DeepMerge.deep_merge!(confine, @confines)
+          confine = component['confine'].transform_values { |val| val.is_a?(Array) ? val.dup : Array(val) }
+          @confines = DeepMerge.deep_merge!(confine, @confines, knockout_prefix: '--')
         end
       end
     end
@@ -349,8 +349,22 @@ class ComplianceEngine::Data
 
     valid_profiles.reverse_each do |profile|
       check_mapping(profile).each_value do |check|
-        parameters = DeepMerge.deep_merge!(check.hiera, parameters)
+        hiera_data = check.hiera
+        next if hiera_data.nil?
+
+        parameters = DeepMerge.deep_merge!(Marshal.load(Marshal.dump(hiera_data)), parameters)
       end
+    end
+
+    # deep_merge does not support hash-key knockout via knockout_prefix.
+    # Handle parameter-name knockout explicitly: any key starting with '--'
+    # signals that the matching key without the prefix should be suppressed
+    # (mirrors compliance_markup behavior).
+    parameters.each_key do |key|
+      next unless key.start_with?('--')
+
+      parameters.delete(key.delete_prefix('--'))
+      parameters.delete(key)
     end
 
     @hiera[cache_key] = parameters

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1149,4 +1149,84 @@ RSpec.describe ComplianceEngine::Data do
       expect(compliance_engine.ces.keys).to eq(['ce_00', 'ce_01', 'ce_02', 'ce_03'])
     end
   end
+
+  context 'with knockout_prefix support' do
+    def setup_module(module_path, file_data)
+      allow(File).to receive(:directory?).with(module_path).and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/SIMP/compliance_profiles").and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/simp/compliance_profiles").and_return(false)
+      allow(Dir).to receive(:glob)
+        .with("#{module_path}/SIMP/compliance_profiles/**/*.yaml")
+        .and_return(file_data.map { |name, _| "#{module_path}/SIMP/compliance_profiles/#{name}" })
+      allow(Dir).to receive(:glob)
+        .with("#{module_path}/SIMP/compliance_profiles/**/*.json")
+        .and_return([])
+      file_data.each do |name, contents|
+        filename = "#{module_path}/SIMP/compliance_profiles/#{name}"
+        allow(File).to receive(:size).with(filename).and_return(contents.length)
+        allow(File).to receive(:mtime).with(filename).and_return(Time.now)
+        allow(File).to receive(:read).with(filename).and_return(contents)
+      end
+    end
+
+    context 'when a check uses a knockout parameter name' do
+      subject(:compliance_engine) { described_class.new('test_module_00') }
+
+      before(:each) do
+        setup_module('test_module_00', {
+                       'a.yaml' => <<~YAML,
+                         ---
+                         version: 2.0.0
+                         profiles:
+                           base_profile:
+                             ces:
+                               base_ce: true
+                         ce:
+                           base_ce:
+                             controls:
+                               control_a: true
+                         checks:
+                           set_param:
+                             type: puppet-class-parameter
+                             settings:
+                               parameter: mymodule::param
+                               value: original_value
+                             ces:
+                               - base_ce
+                       YAML
+          'b.yaml' => <<~YAML,
+            ---
+            version: 2.0.0
+            profiles:
+              knockout_profile:
+                ces:
+                  knockout_ce: true
+            ce:
+              knockout_ce:
+                controls:
+                  control_b: true
+            checks:
+              knockout_param:
+                type: puppet-class-parameter
+                settings:
+                  parameter: "--mymodule::param"
+                  value: ~
+                ces:
+                  - knockout_ce
+          YAML
+                     })
+      end
+
+      it 'knocks out the parameter when both profiles are requested' do
+        hiera = compliance_engine.hiera(['base_profile', 'knockout_profile'])
+        expect(hiera).not_to have_key('mymodule::param')
+        expect(hiera).not_to have_key('--mymodule::param')
+      end
+
+      it 'still returns the parameter when only the base profile is requested' do
+        hiera = compliance_engine.hiera(['base_profile'])
+        expect(hiera).to include('mymodule::param' => 'original_value')
+      end
+    end
+  end
 end

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1545,4 +1545,84 @@ RSpec.describe ComplianceEngine::Data do
       expect(compliance_engine.ces.keys).to eq(['ce_00', 'ce_01', 'ce_02', 'ce_03'])
     end
   end
+
+  context 'with knockout_prefix support' do
+    def setup_module(module_path, file_data)
+      allow(File).to receive(:directory?).with(module_path).and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/SIMP/compliance_profiles").and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/simp/compliance_profiles").and_return(false)
+      allow(Dir).to receive(:glob)
+        .with("#{module_path}/SIMP/compliance_profiles/**/*.yaml")
+        .and_return(file_data.map { |name, _| "#{module_path}/SIMP/compliance_profiles/#{name}" })
+      allow(Dir).to receive(:glob)
+        .with("#{module_path}/SIMP/compliance_profiles/**/*.json")
+        .and_return([])
+      file_data.each do |name, contents|
+        filename = "#{module_path}/SIMP/compliance_profiles/#{name}"
+        allow(File).to receive(:size).with(filename).and_return(contents.length)
+        allow(File).to receive(:mtime).with(filename).and_return(Time.now)
+        allow(File).to receive(:read).with(filename).and_return(contents)
+      end
+    end
+
+    context 'when a check uses a knockout parameter name' do
+      subject(:compliance_engine) { described_class.new('test_module_00') }
+
+      before(:each) do
+        setup_module('test_module_00', {
+                       'a.yaml' => <<~YAML,
+                         ---
+                         version: 2.0.0
+                         profiles:
+                           base_profile:
+                             ces:
+                               base_ce: true
+                         ce:
+                           base_ce:
+                             controls:
+                               control_a: true
+                         checks:
+                           set_param:
+                             type: puppet-class-parameter
+                             settings:
+                               parameter: mymodule::param
+                               value: original_value
+                             ces:
+                               - base_ce
+                       YAML
+          'b.yaml' => <<~YAML,
+            ---
+            version: 2.0.0
+            profiles:
+              knockout_profile:
+                ces:
+                  knockout_ce: true
+            ce:
+              knockout_ce:
+                controls:
+                  control_b: true
+            checks:
+              knockout_param:
+                type: puppet-class-parameter
+                settings:
+                  parameter: "--mymodule::param"
+                  value: ~
+                ces:
+                  - knockout_ce
+          YAML
+                     })
+      end
+
+      it 'knocks out the parameter when both profiles are requested' do
+        hiera = compliance_engine.hiera(['base_profile', 'knockout_profile'])
+        expect(hiera).not_to have_key('mymodule::param')
+        expect(hiera).not_to have_key('--mymodule::param')
+      end
+
+      it 'still returns the parameter when only the base profile is requested' do
+        hiera = compliance_engine.hiera(['base_profile'])
+        expect(hiera).to include('mymodule::param' => 'original_value')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add support for knocking out Hiera parameters by prefixing a check's parameter name with '--' (e.g. '--mymodule::param'), mirroring the behavior of the compliance_markup module.

deep_merge's knockout_prefix option does not remove Hash keys, only Array elements.  Instead, a manual post-merge loop scans for keys starting with '--', deletes the unprefixed counterpart, and removes the knockout key.  The confines method receives a Marshal deep-copy before merging to protect frozen DataLoader source data.

Closes #25