### PR TITLE
fix: handle and test malformed compliance data gracefully

### DIFF
--- a/lib/compliance_engine/collection.rb
+++ b/lib/compliance_engine/collection.rb
@@ -12,7 +12,15 @@ class ComplianceEngine::Collection
     @collection ||= {}
     hash_key = key
     data.files.each do |file|
-      data.get(file)[hash_key]&.each do |k, v|
+      entries = data.get(file)[hash_key]
+      next if entries.nil?
+
+      unless entries.is_a?(Hash)
+        ComplianceEngine.log.error "Expected '#{hash_key}' in #{file} to be a Hash, got #{entries.class}"
+        next
+      end
+
+      entries.each do |k, v|
         @collection[k] ||= collected.new(k, data: self)
         @collection[k].add(file, v)
       end

--- a/lib/compliance_engine/collection.rb
+++ b/lib/compliance_engine/collection.rb
@@ -12,7 +12,13 @@ class ComplianceEngine::Collection
     @collection ||= {}
     hash_key = key
     data.files.each do |file|
-      entries = data.get(file)[hash_key]
+      file_data = data.get(file)
+      unless file_data.is_a?(Hash)
+        ComplianceEngine.log.debug "Skipping #{file}: expected Hash content, got #{file_data.class}"
+        next
+      end
+
+      entries = file_data[hash_key]
       next if entries.nil?
 
       unless entries.is_a?(Hash)

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe ComplianceEngine::Data do
       allow(File).to receive(:size).with('file').and_return(0)
       allow(File).to receive(:mtime).with('file').and_return(Time.now)
       allow(File).to receive(:read).with('file').and_return('')
+      allow(ComplianceEngine.log).to receive(:error)
     end
 
     it 'initializes' do
@@ -163,7 +164,6 @@ RSpec.describe ComplianceEngine::Data do
     end
 
     it 'logs an error' do
-      allow(ComplianceEngine.log).to receive(:error)
       compliance_engine.files
       expect(ComplianceEngine.log).to have_received(:error).with('Data must be a hash')
     end
@@ -178,6 +178,7 @@ RSpec.describe ComplianceEngine::Data do
       allow(File).to receive(:size).with('file').and_return(0)
       allow(File).to receive(:mtime).with('file').and_return(Time.now)
       allow(File).to receive(:read).with('file').and_return("---\nversion: 1.0")
+      allow(ComplianceEngine.log).to receive(:error)
     end
 
     it 'initializes' do
@@ -194,7 +195,6 @@ RSpec.describe ComplianceEngine::Data do
     end
 
     it 'logs an error' do
-      allow(ComplianceEngine.log).to receive(:error)
       compliance_engine.files
       expect(ComplianceEngine.log).to have_received(:error).with("Unsupported version '1.0'")
     end

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe ComplianceEngine::Data do
     it 'get returns nil' do
       expect(compliance_engine.get('file')).to be_nil
     end
+
+    it 'logs an error' do
+      allow(ComplianceEngine.log).to receive(:error)
+      compliance_engine.files
+      expect(ComplianceEngine.log).to have_received(:error).with('Data must be a hash')
+    end
   end
 
   context 'with an invalid version number' do
@@ -185,6 +191,154 @@ RSpec.describe ComplianceEngine::Data do
 
     it 'get returns nil' do
       expect(compliance_engine.get('file')).to be_nil
+    end
+
+    it 'logs an error' do
+      allow(ComplianceEngine.log).to receive(:error)
+      compliance_engine.files
+      expect(ComplianceEngine.log).to have_received(:error).with("Unsupported version '1.0'")
+    end
+  end
+
+  context 'with a missing version key' do
+    subject(:compliance_engine) { described_class.new('file') }
+
+    before(:each) do
+      allow(File).to receive(:directory?).with('file').and_return(false)
+      allow(File).to receive(:file?).with('file').and_return(true)
+      allow(File).to receive(:size).with('file').and_return(0)
+      allow(File).to receive(:mtime).with('file').and_return(Time.now)
+      allow(File).to receive(:read).with('file').and_return("---\nprofiles: {}")
+      allow(ComplianceEngine.log).to receive(:error)
+    end
+
+    it 'initializes without raising' do
+      expect { compliance_engine }.not_to raise_error
+    end
+
+    it 'returns an empty list of files' do
+      expect(compliance_engine.files).to eq([])
+    end
+
+    it 'logs an error' do
+      compliance_engine.files
+      expect(ComplianceEngine.log).to have_received(:error).with('Missing version')
+    end
+  end
+
+  context 'with malformed YAML content' do
+    subject(:compliance_engine) { described_class.new('file') }
+
+    before(:each) do
+      allow(File).to receive(:directory?).with('file').and_return(false)
+      allow(File).to receive(:file?).with('file').and_return(true)
+      allow(File).to receive(:size).with('file').and_return(0)
+      allow(File).to receive(:mtime).with('file').and_return(Time.now)
+      allow(File).to receive(:read).with('file').and_return("---\nkey: {unclosed")
+      allow(ComplianceEngine.log).to receive(:error)
+    end
+
+    it 'initializes without raising' do
+      expect { compliance_engine }.not_to raise_error
+    end
+
+    it 'returns an empty list of files' do
+      expect(compliance_engine.files).to eq([])
+    end
+
+    it 'logs an error' do
+      compliance_engine.files
+      expect(ComplianceEngine.log).to have_received(:error)
+    end
+  end
+
+  context 'with a non-hash collection value in data' do
+    subject(:compliance_engine) { described_class.new('file') }
+
+    before(:each) do
+      allow(File).to receive(:directory?).with('file').and_return(false)
+      allow(File).to receive(:file?).with('file').and_return(true)
+      allow(File).to receive(:size).with('file').and_return(0)
+      allow(File).to receive(:mtime).with('file').and_return(Time.now)
+      allow(File).to receive(:read).with('file').and_return(
+        "---\nversion: '2.0.0'\nprofiles: not_a_hash\n",
+      )
+      allow(ComplianceEngine.log).to receive(:error)
+    end
+
+    it 'initializes without raising' do
+      expect { compliance_engine }.not_to raise_error
+    end
+
+    it 'returns the file as loaded' do
+      expect(compliance_engine.files).to eq(['file'])
+    end
+
+    it 'returns an empty profiles collection' do
+      expect(compliance_engine.profiles.keys).to eq([])
+    end
+
+    it 'logs an error for the invalid profiles value' do
+      compliance_engine.profiles
+      expect(ComplianceEngine.log).to have_received(:error).with(%r{Expected 'profiles' in file to be a Hash})
+    end
+  end
+
+  context 'with one valid file and one malformed file' do
+    subject(:compliance_engine) { described_class.new('good_file', 'bad_file') }
+
+    let(:good_content) do
+      <<~YAML
+        ---
+        version: '2.0.0'
+        profiles:
+          valid_profile:
+            ces:
+              valid_ce: true
+        ce:
+          valid_ce: {}
+        checks:
+          valid_check:
+            type: puppet-class-parameter
+            settings:
+              parameter: mymodule::param
+              value: valid_value
+            ces:
+              - valid_ce
+      YAML
+    end
+
+    before(:each) do
+      allow(File).to receive(:directory?).with('good_file').and_return(false)
+      allow(File).to receive(:file?).with('good_file').and_return(true)
+      allow(File).to receive(:size).with('good_file').and_return(good_content.length)
+      allow(File).to receive(:mtime).with('good_file').and_return(Time.now)
+      allow(File).to receive(:read).with('good_file').and_return(good_content)
+
+      allow(File).to receive(:directory?).with('bad_file').and_return(false)
+      allow(File).to receive(:file?).with('bad_file').and_return(true)
+      allow(File).to receive(:size).with('bad_file').and_return(0)
+      allow(File).to receive(:mtime).with('bad_file').and_return(Time.now)
+      allow(File).to receive(:read).with('bad_file').and_return("---\nversion: 1.0")
+
+      allow(ComplianceEngine.log).to receive(:error)
+    end
+
+    it 'initializes without raising' do
+      expect { compliance_engine }.not_to raise_error
+    end
+
+    it 'loads the valid file and skips the malformed file' do
+      expect(compliance_engine.files).to eq(['good_file'])
+    end
+
+    it 'logs an error for the malformed file' do
+      compliance_engine.files
+      expect(ComplianceEngine.log).to have_received(:error).with("Unsupported version '1.0'")
+    end
+
+    it 'returns hiera data from the valid file' do
+      expect(compliance_engine.hiera(['valid_profile'])).to include('mymodule::param' => 'valid_value')
     end
   end
 


### PR DESCRIPTION
Malformed data is logged as an error but must not crash the system.

Collection#initialize previously called `&.each` on the value of a collection key (profiles, ce, checks, controls) without type-checking it first.  If a file had a valid version but a non-Hash value for one of those keys (e.g. `profiles: not_a_hash`), Ruby would raise NoMethodError propagating up to the caller.  Add an explicit Hash check that logs a descriptive error and skips the offending file section instead of crashing.

Tests added in data_spec.rb verify:
- Empty file content → error logged, file skipped
- Invalid version number → error logged, file skipped
- Missing version key → error logged, file skipped
- Malformed YAML (parse error) → error logged, file skipped
- Non-hash collection value → error logged, collection empty
- Partial recovery: valid files load correctly when others are malformed

Closes #32