### PR TITLE
fix: make dotfile loading optional, defaulting to off

### DIFF
--- a/lib/compliance_engine/environment_loader.rb
+++ b/lib/compliance_engine/environment_loader.rb
@@ -11,7 +11,9 @@ class ComplianceEngine::EnvironmentLoader
   # @param fileclass [File] the class to use for file operations (default: `File`)
   # @param dirclass [Dir] the class to use for directory operations (default: `Dir`)
   # @param zipfile_path [String, nil] the path to the zip file if loading from a zip archive
-  def initialize(*paths, fileclass: File, dirclass: Dir, zipfile_path: nil)
+  # @param load_dotfiles [Boolean] whether to load dotfiles; passed through to
+  #   each ModuleLoader (default: false)
+  def initialize(*paths, fileclass: File, dirclass: Dir, zipfile_path: nil, load_dotfiles: false)
     raise ArgumentError, 'No paths specified' if paths.empty?
 
     @modulepath ||= paths
@@ -26,7 +28,7 @@ class ComplianceEngine::EnvironmentLoader
       []
     end
     modules.flatten!
-    @modules = modules.map { |path| ComplianceEngine::ModuleLoader.new(path, fileclass: fileclass, dirclass: dirclass, zipfile_path: @zipfile_path) }
+    @modules = modules.map { |path| ComplianceEngine::ModuleLoader.new(path, fileclass: fileclass, dirclass: dirclass, zipfile_path: @zipfile_path, load_dotfiles: load_dotfiles) }
   end
 
   attr_reader :modulepath, :modules, :zipfile_path

--- a/lib/compliance_engine/environment_loader/zip.rb
+++ b/lib/compliance_engine/environment_loader/zip.rb
@@ -18,7 +18,7 @@ class ComplianceEngine::EnvironmentLoader::Zip < ComplianceEngine::EnvironmentLo
       dir = zipfile.dir
       file = zipfile.file
 
-      super(root, fileclass: file, dirclass: dir, zipfile_path: path)
+      super(root, fileclass: file, dirclass: dir, zipfile_path: path, load_dotfiles: true)
     end
   end
 end

--- a/lib/compliance_engine/environment_loader/zip.rb
+++ b/lib/compliance_engine/environment_loader/zip.rb
@@ -11,14 +11,16 @@ class ComplianceEngine::EnvironmentLoader::Zip < ComplianceEngine::EnvironmentLo
   #
   # @param path [String] the path to the zip file containing the Puppet environment
   # @param root [String] a directory within the zip file to use as the root of the environment
-  def initialize(path, root: '/'.dup)
+  # @param load_dotfiles [Boolean] whether to load dotfiles; defaults to true to
+  #   preserve the historical zip-loader behaviour of including all files
+  def initialize(path, root: '/'.dup, load_dotfiles: true)
     @modulepath = path
 
     ::Zip::File.open(path) do |zipfile|
       dir = zipfile.dir
       file = zipfile.file
 
-      super(root, fileclass: file, dirclass: dir, zipfile_path: path, load_dotfiles: true)
+      super(root, fileclass: file, dirclass: dir, zipfile_path: path, load_dotfiles: load_dotfiles)
     end
   end
 end

--- a/lib/compliance_engine/module_loader.rb
+++ b/lib/compliance_engine/module_loader.rb
@@ -12,7 +12,12 @@ class ComplianceEngine::ModuleLoader
   # @param fileclass [File] the class to use for file operations (default: `File`)
   # @param dirclass [Dir] the class to use for directory operations (default: `Dir`)
   # @param zipfile_path [String, nil] the path to the zip file if loading from a zip archive
-  def initialize(path, fileclass: File, dirclass: Dir, zipfile_path: nil)
+  # @param load_dotfiles [Boolean] whether to load files whose relative path contains
+  #   a component (directory or filename) beginning with '.'. Defaults to false so that
+  #   dotfiles are skipped during normal module scanning, matching the behavior of
+  #   Ruby's Dir.glob on real filesystems. Set to true only when the caller explicitly
+  #   needs dotfile support (e.g. zip-based environment loading).
+  def initialize(path, fileclass: File, dirclass: Dir, zipfile_path: nil, load_dotfiles: false)
     raise ComplianceEngine::Error, "#{path} is not a directory" unless fileclass.directory?(path)
 
     @name = nil
@@ -34,27 +39,39 @@ class ComplianceEngine::ModuleLoader
 
     # In this directory, we want to look for all yaml and json files
     # under SIMP/compliance_profiles and simp/compliance_profiles.
-    globs = ['SIMP/compliance_profiles', 'simp/compliance_profiles']
-            .select { |dir| fileclass.directory?(File.join(path, dir)) }
-            .map { |dir|
-      ['yaml', 'json'].map { |type| File.join(path, dir, '**', "*.#{type}") }
-    }.flatten
-    # Using .each here to make mocking with rspec easier.
-    globs.each do |glob|
-      dirclass.glob(glob).sort.each do |file|
-        key = if @zipfile_path
-                File.join(@zipfile_path, '.', file.to_s)
-              else
-                file.to_s
-              end
-        loader = if File.extname(file.to_s) == '.json'
-                   ComplianceEngine::DataLoader::Json.new(file.to_s, fileclass: fileclass, key: key)
-                 else
-                   ComplianceEngine::DataLoader::Yaml.new(file.to_s, fileclass: fileclass, key: key)
-                 end
-        @files << loader
-      rescue StandardError => e
-        ComplianceEngine.log.warn "Could not load #{file}: #{e.message}"
+    # The loops are structured this way (rather than building a flat globs
+    # array first) so that each glob result can be checked against its
+    # base directory for dotfile filtering.
+    ['SIMP/compliance_profiles', 'simp/compliance_profiles'].each do |dir|
+      base = File.join(path, dir)
+      next unless fileclass.directory?(base)
+
+      # Using .each here to make mocking with rspec easier.
+      ['yaml', 'json'].each do |type|
+        dirclass.glob(File.join(base, '**', "*.#{type}")).sort.each do |file|
+          unless load_dotfiles
+            # Skip any file whose path (relative to the compliance_profiles
+            # base) contains a component beginning with '.', e.g. hidden
+            # files (.profile.yaml) or files inside hidden directories
+            # (.hidden/profile.yaml).
+            relative = file.to_s.delete_prefix("#{base}/")
+            next if relative.split('/').any? { |part| part.start_with?('.') }
+          end
+
+          key = if @zipfile_path
+                  File.join(@zipfile_path, '.', file.to_s)
+                else
+                  file.to_s
+                end
+          loader = if File.extname(file.to_s) == '.json'
+                     ComplianceEngine::DataLoader::Json.new(file.to_s, fileclass: fileclass, key: key)
+                   else
+                     ComplianceEngine::DataLoader::Yaml.new(file.to_s, fileclass: fileclass, key: key)
+                   end
+          @files << loader
+        rescue StandardError => e
+          ComplianceEngine.log.warn "Could not load #{file}: #{e.message}"
+        end
       end
     end
   end

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -47,5 +47,15 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       expect(environment_loader.modules.count).to eq(2)
       expect(environment_loader.modulepath).to eq(path)
     end
+
+    it 'passes load_dotfiles: true to ModuleLoader by default' do
+      environment_loader
+      expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: true)).at_least(:once)
+    end
+
+    it 'passes load_dotfiles: false to ModuleLoader when requested' do
+      described_class.new(path, load_dotfiles: false)
+      expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: false)).at_least(:once)
+    end
   end
 end

--- a/spec/classes/compliance_engine/environment_loader_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader_spec.rb
@@ -55,5 +55,15 @@ RSpec.describe ComplianceEngine::EnvironmentLoader do
       expect(environment_loader.modules.count).to eq(2)
       expect(environment_loader.modulepath).to eq(paths)
     end
+
+    it 'passes load_dotfiles: false to ModuleLoader by default' do
+      environment_loader
+      expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: false)).at_least(:once)
+    end
+
+    it 'passes load_dotfiles: true to ModuleLoader when requested' do
+      described_class.new(*paths, load_dotfiles: true)
+      expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: true)).at_least(:once)
+    end
   end
 end

--- a/spec/classes/compliance_engine/module_loader_spec.rb
+++ b/spec/classes/compliance_engine/module_loader_spec.rb
@@ -52,6 +52,65 @@ RSpec.describe ComplianceEngine::ModuleLoader do
     end
   end
 
+  context 'dotfile handling' do
+    let(:module_path) { 'test_module_dot' }
+    let(:normal_content) { "---\nversion: '2.0.0'\nprofiles: {}\n" }
+    let(:dot_content)    { "---\nversion: '2.0.0'\nprofiles: {dot: true}\n" }
+
+    before(:each) do
+      allow(File).to receive(:directory?).with(module_path).and_return(true)
+      allow(File).to receive(:exist?).with("#{module_path}/metadata.json").and_return(false)
+      allow(File).to receive(:directory?).with("#{module_path}/SIMP/compliance_profiles").and_return(true)
+      allow(File).to receive(:directory?).with("#{module_path}/simp/compliance_profiles").and_return(false)
+      allow(Dir).to receive(:glob)
+        .with("#{module_path}/SIMP/compliance_profiles/**/*.json")
+        .and_return([])
+
+      # Glob returns both a normal file and two dotfile paths.
+      allow(Dir).to receive(:glob)
+        .with("#{module_path}/SIMP/compliance_profiles/**/*.yaml")
+        .and_return([
+                      "#{module_path}/SIMP/compliance_profiles/normal.yaml",
+                      "#{module_path}/SIMP/compliance_profiles/.hidden.yaml",
+                      "#{module_path}/SIMP/compliance_profiles/.dotdir/nested.yaml",
+                    ])
+
+      [
+        ['normal.yaml', normal_content],
+        ['.hidden.yaml', dot_content],
+        ['.dotdir/nested.yaml', dot_content],
+      ].each do |name, contents|
+        filename = "#{module_path}/SIMP/compliance_profiles/#{name}"
+        allow(File).to receive(:size).with(filename).and_return(contents.length)
+        allow(File).to receive(:mtime).with(filename).and_return(Time.now)
+        allow(File).to receive(:read).with(filename).and_return(contents)
+      end
+    end
+
+    context 'by default (load_dotfiles: false)' do
+      subject(:module_loader) { described_class.new(module_path) }
+
+      it 'excludes dotfiles and files inside dot-directories' do
+        expect(module_loader.files.map(&:key)).to eq(
+          ["#{module_path}/SIMP/compliance_profiles/normal.yaml"],
+        )
+      end
+    end
+
+    context 'with load_dotfiles: true' do
+      subject(:module_loader) { described_class.new(module_path, load_dotfiles: true) }
+
+      it 'includes dotfiles and files inside dot-directories' do
+        # .sort puts dot-prefixed names before regular names (ASCII order)
+        expect(module_loader.files.map(&:key)).to eq([
+                                                       "#{module_path}/SIMP/compliance_profiles/.dotdir/nested.yaml",
+                                                       "#{module_path}/SIMP/compliance_profiles/.hidden.yaml",
+                                                       "#{module_path}/SIMP/compliance_profiles/normal.yaml",
+                                                     ])
+      end
+    end
+  end
+
   context 'with module data' do
     subject(:module_loader) { described_class.new(test_data.keys.first) }
 


### PR DESCRIPTION
When loading via Dir.glob on a real filesystem, Ruby's glob engine skips hidden files and directories (those starting with '.') because the default '*' pattern does not match dot-prefixed names.  The zip filesystem adapter (rubyzip's Zip::FileSystem) does not share this behaviour and could return dotfiles from its glob, leading to inconsistent results depending on how the environment was loaded.

Add a `load_dotfiles:` keyword argument (default: false) to ModuleLoader and thread it through EnvironmentLoader.  When false, any file whose path relative to the compliance_profiles base directory contains a component beginning with '.' -- whether the filename itself (.profile.yaml) or an intermediate directory (.hidden/profile.yaml) -- is skipped after the glob.

EnvironmentLoader::Zip passes load_dotfiles: true so that its existing behaviour (loading dotfiles from zip archives) is preserved and callers who depend on it are not silently broken.

Closes #52