### PR TITLE
feat: accept ::Zip::File input in EnvironmentLoader::Zip

### DIFF
--- a/lib/compliance_engine/environment_loader/zip.rb
+++ b/lib/compliance_engine/environment_loader/zip.rb
@@ -9,18 +9,21 @@ class ComplianceEngine::EnvironmentLoader::Zip < ComplianceEngine::EnvironmentLo
   # Initialize a ComplianceEngine::EnvironmentLoader::Zip object from a zip
   # file and an optional root directory.
   #
-  # @param path [String] the path to the zip file containing the Puppet environment
+  # @param input [String, ::Zip::File] either a filesystem path to a zip file,
+  #   or an already-opened ::Zip::File (e.g. from Zip::File.open_buffer); when
+  #   a ::Zip::File is passed, the caller owns its lifecycle
   # @param root [String] a directory within the zip file to use as the root of the environment
   # @param load_dotfiles [Boolean] whether to load dotfiles; defaults to true to
   #   preserve the historical zip-loader behaviour of including all files
-  def initialize(path, root: '/'.dup, load_dotfiles: true)
-    @modulepath = path
-
-    ::Zip::File.open(path) do |zipfile|
-      dir = zipfile.dir
-      file = zipfile.file
-
-      super(root, fileclass: file, dirclass: dir, zipfile_path: path, load_dotfiles: load_dotfiles)
-    end
+  # @param name [String, nil] identifier used for modulepath and downstream
+  #   cache keys; defaults to the zip's #name (the path on disk, or "-" for
+  #   buffer-opened zips). Pass an explicit value when loading a buffer-opened
+  #   zip to keep cache keys unique and logs informative.
+  def initialize(input, root: '/'.dup, load_dotfiles: true, name: nil)
+    zipfile = input.is_a?(::Zip::File) ? input : ::Zip::File.open(input)
+    @modulepath = name || zipfile.name
+    super(root, fileclass: zipfile.file, dirclass: zipfile.dir, zipfile_path: @modulepath, load_dotfiles: load_dotfiles)
+  ensure
+    zipfile.close if zipfile && !input.is_a?(::Zip::File)
   end
 end

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -58,4 +58,46 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: false)).at_least(:once)
     end
   end
+
+  context 'with an opened ::Zip::File' do
+    subject(:environment_loader) { described_class.new(zipfile) }
+
+    let(:path) { File.expand_path('../../../fixtures/test_environment.zip', __dir__) }
+    let(:zipfile) { Zip::File.open(path) }
+
+    before(:each) do
+      allow(ComplianceEngine::ModuleLoader).to receive(:new).and_return(instance_double(ComplianceEngine::ModuleLoader))
+    end
+
+    it 'initializes' do
+      expect(environment_loader).to be_instance_of(described_class)
+    end
+
+    it 'defaults modulepath to the zipfile name' do
+      expect(environment_loader.modulepath).to eq(zipfile.name)
+      expect(environment_loader.zipfile_path).to eq(zipfile.name)
+    end
+
+    it 'loads modules from the opened zip' do
+      expect(environment_loader.modules).to be_instance_of(Array)
+      expect(environment_loader.modules.count).to eq(2)
+    end
+  end
+
+  context 'with an explicit name' do
+    subject(:environment_loader) { described_class.new(zipfile, name: name) }
+
+    let(:path) { File.expand_path('../../../fixtures/test_environment.zip', __dir__) }
+    let(:zipfile) { Zip::File.open(path) }
+    let(:name) { '/outer.zip!modules.zip' }
+
+    before(:each) do
+      allow(ComplianceEngine::ModuleLoader).to receive(:new).and_return(instance_double(ComplianceEngine::ModuleLoader))
+    end
+
+    it 'uses the explicit name for modulepath and zipfile_path' do
+      expect(environment_loader.modulepath).to eq(name)
+      expect(environment_loader.zipfile_path).to eq(name)
+    end
+  end
 end

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       expect(environment_loader.modulepath).to eq(path)
     end
 
+    it 'sets zipfile_path to the path' do
+      expect(environment_loader.zipfile_path).to eq(path)
+    end
+
+    it 'closes the zip after initialization' do
+      close_called = false
+      allow(Zip::File).to receive(:open).and_wrap_original do |original, p|
+        zip = original.call(p)
+        allow(zip).to receive(:close).and_wrap_original { |m, *args| close_called = true; m.call(*args) }
+        zip
+      end
+      environment_loader
+      expect(close_called).to be true
+    end
+
     it 'passes load_dotfiles: true to ModuleLoader by default' do
       environment_loader
       expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: true)).at_least(:once)
@@ -83,6 +98,48 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
     it 'loads modules from the opened zip' do
       expect(environment_loader.modules).to be_instance_of(Array)
       expect(environment_loader.modules.count).to eq(2)
+    end
+
+    it 'does not close the caller-provided zip' do
+      closed_during_init = false
+      allow(zipfile).to receive(:close).and_wrap_original do |original|
+        closed_during_init = true
+        original.call
+      end
+      environment_loader
+      expect(closed_during_init).to be false
+    end
+
+    it 'does not call Zip::File.open' do
+      zipfile  # materialise the let before restricting Zip::File.open
+      expect(Zip::File).not_to receive(:open)
+      environment_loader
+    end
+
+    it 'passes load_dotfiles: true to ModuleLoader by default' do
+      environment_loader
+      expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: true)).at_least(:once)
+    end
+
+    it 'passes load_dotfiles: false to ModuleLoader when requested' do
+      described_class.new(zipfile, load_dotfiles: false)
+      expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: false)).at_least(:once)
+    end
+  end
+
+  context 'with a valid zip and an explicit name' do
+    subject(:environment_loader) { described_class.new(path, name: name) }
+
+    let(:path) { File.expand_path('../../../fixtures/test_environment.zip', __dir__) }
+    let(:name) { 'custom_name.zip' }
+
+    before(:each) do
+      allow(ComplianceEngine::ModuleLoader).to receive(:new).and_return(instance_double(ComplianceEngine::ModuleLoader))
+    end
+
+    it 'uses the explicit name for modulepath and zipfile_path' do
+      expect(environment_loader.modulepath).to eq(name)
+      expect(environment_loader.zipfile_path).to eq(name)
     end
   end
 

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -69,6 +69,8 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       allow(ComplianceEngine::ModuleLoader).to receive(:new).and_return(instance_double(ComplianceEngine::ModuleLoader))
     end
 
+    after(:each) { zipfile.close }
+
     it 'initializes' do
       expect(environment_loader).to be_instance_of(described_class)
     end
@@ -94,6 +96,8 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
     before(:each) do
       allow(ComplianceEngine::ModuleLoader).to receive(:new).and_return(instance_double(ComplianceEngine::ModuleLoader))
     end
+
+    after(:each) { zipfile.close }
 
     it 'uses the explicit name for modulepath and zipfile_path' do
       expect(environment_loader.modulepath).to eq(name)

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -56,7 +56,10 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       close_called = false
       allow(Zip::File).to receive(:open).and_wrap_original do |original, p|
         zip = original.call(p)
-        allow(zip).to receive(:close).and_wrap_original { |m, *args| close_called = true; m.call(*args) }
+        allow(zip).to(receive(:close).and_wrap_original do |m, *args|
+          close_called = true
+          m.call(*args)
+        end)
         zip
       end
       environment_loader
@@ -111,9 +114,10 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
     end
 
     it 'does not call Zip::File.open' do
-      zipfile  # materialise the let before restricting Zip::File.open
-      expect(Zip::File).not_to receive(:open)
+      allow(Zip::File).to receive(:open).and_call_original
+      zipfile # materialise the let; the one permitted Zip::File.open call
       environment_loader
+      expect(Zip::File).to have_received(:open).once
     end
 
     it 'passes load_dotfiles: true to ModuleLoader by default' do


### PR DESCRIPTION
- Accept either a path String (existing behavior) or an already-opened ::Zip::File so callers can hand in buffer-opened zips (e.g. an inner archive extracted from an outer zip via Zip::File.open_buffer) without writing the bytes to disk first.
- Add optional `name:` keyword to override the identifier used for `modulepath` and the downstream ModuleLoader cache key; defaults to the zip's #name, which is "-" for buffer-opened zips. Pass an explicit value to keep cache keys unique and logs informative when loading multiple buffer-opened zips into the same Data instance.
- Caller owns the lifecycle of any ::Zip::File they pass in; the loader only closes zips it opened itself (preserving prior block-form behavior for the path branch).
- Add spec coverage for the ::Zip::File input branch and the explicit `name:` override.

closes #113 