### PR TITLE
feat: honor explicit `false` in profile mappings as exclusions (#117)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ A component can have multiple **fragments** (one per source file), which are dee
 | CE→Control overlap | Any of `check.ces`' CEs has a control that also appears in `profile.controls` |
 | Direct reference | `profile.checks[check_key]` is truthy |
 
+An entry on the **profile side** with value `false` is treated as an **explicit exclusion** that overrides positive matches: `profile.checks[X] = false` hard-excludes check `X` from every route, and `profile.ces[X] = false` prevents CE `X` from being used as either a direct CE match or as a CE→Control bridge. On the **check side**, `false` is local-only (e.g. `check.controls[X] = false` simply means the check is not associated with control `X`); `check.ces` is an array, so no `false` handling applies.
+
 `check_mapping` can also be called with CE objects (in addition to profiles). Results are cached by `"#{object.class}:#{object.key}"`.
 
 ### Loading Pipeline

--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -439,6 +439,9 @@ class ComplianceEngine::Data
     cache_key = [check.key, "#{profile_or_ce.class}:#{profile_or_ce.key}"].to_s
     return @mapping[cache_key] if @mapping.key?(cache_key)
 
+    # An explicit `false` on the profile side hard-excludes the check, regardless of any other route.
+    return @mapping[cache_key] = false if profile_or_ce.is_a?(ComplianceEngine::Profile) && profile_or_ce.checks&.dig(check.key) == false
+
     # Correlate based on controls
     controls = check.controls&.select { |_, v| v }&.map { |k, _| k }
 
@@ -457,9 +460,10 @@ class ComplianceEngine::Data
     # Correlate based on CEs
     return @mapping[cache_key] = true if correlate(check.ces, profile_or_ce.ces)
 
-    # Correlate based on CEs and controls
-    return @mapping[cache_key] = true if profile_or_ce.ces&.any? { |k, _| correlate(controls, ces[k]&.controls) }
-    return @mapping[cache_key] = true if check.ces&.any? { |ce| ces[ce]&.controls&.any? { |k, v| v && profile_or_ce.controls&.dig(k) } }
+    # Correlate based on CEs and controls. A CE explicitly set to `false` in the profile
+    # cannot be used as a bridge; absence (nil) still allows the bridge.
+    return @mapping[cache_key] = true if profile_or_ce.ces&.any? { |k, v| v && correlate(controls, ces[k]&.controls) }
+    return @mapping[cache_key] = true if check.ces&.any? { |ce| profile_or_ce.ces&.dig(ce) != false && ces[ce]&.controls&.any? { |k, v| v && profile_or_ce.controls&.dig(k) } }
 
     @mapping[cache_key] = false
   end

--- a/lib/compliance_engine/sce-schema.json
+++ b/lib/compliance_engine/sce-schema.json
@@ -51,7 +51,7 @@
     },
     "controlsMap": {
       "type": "object",
-      "title": "References to top-level controls entries. Enforced when value is true.",
+      "title": "References to top-level controls entries. Enforced when value is true; explicitly excluded when value is false.",
       "patternProperties": {
         "^\\w(?:[\\w.-]*[\\w-])?(?::\\w(?:[\\w.-]*[\\w-])?)*$": {
           "type": "boolean",
@@ -132,7 +132,7 @@
             "ces": {
               "type": "object",
               "default": {},
-              "title": "CEs to include in this profile. Enforced when value is true.",
+              "title": "CEs to include in this profile. Enforced when value is true; explicitly excluded when value is false (overrides any positive mapping route).",
               "patternProperties": {
                 "^\\w(?:[\\w.-]*[\\w-])?(?::\\w(?:[\\w.-]*[\\w-])?)*$": {
                   "type": "boolean",
@@ -151,7 +151,7 @@
             "checks": {
               "type": "object",
               "default": {},
-              "title": "Checks to include in this profile. Enforced when value is true.",
+              "title": "Checks to include in this profile. Enforced when value is true; hard-excluded when value is false (overrides any positive mapping route).",
               "patternProperties": {
                 "^\\w(?:[\\w.-]*[\\w-])?(?::\\w(?:[\\w.-]*[\\w-])?)*$": {
                   "type": "boolean",

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1305,6 +1305,140 @@ RSpec.describe ComplianceEngine::Data do
     end
   end
 
+  context 'with explicit `false` exclusions in profile mappings' do
+    def test_data
+      {
+        'test_module_00' => {
+          'a/file.yaml' => <<~A_YAML,
+            ---
+            version: 2.0.0
+            profiles:
+              profile_with_excluded_ce:
+                controls:
+                  XY-n: true
+                ces:
+                  abc: false
+              profile_with_excluded_check:
+                controls:
+                  XY-n: true
+                checks:
+                  excluded_check: false
+              profile_with_partial_ce_exclusion:
+                controls:
+                  XY-n: true
+                ces:
+                  xyz: false
+              profile_baseline:
+                controls:
+                  XY-n: true
+            ce:
+              abc:
+                controls:
+                  XY-n: true
+              xyz:
+                controls:
+                  XY-n: true
+              other_ce:
+                controls:
+                  XY-n: true
+            checks:
+              check_via_excluded_ce:
+                type: 'puppet-class-parameter'
+                settings:
+                  parameter: 'test_module_00::via_excluded_ce'
+                  value: 'should be excluded'
+                ces:
+                  - abc
+              check_via_other_ce:
+                type: 'puppet-class-parameter'
+                settings:
+                  parameter: 'test_module_00::via_other_ce'
+                  value: 'should be included'
+                ces:
+                  - other_ce
+              check_via_two_ces:
+                type: 'puppet-class-parameter'
+                settings:
+                  parameter: 'test_module_00::via_two_ces'
+                  value: 'should be included via abc'
+                ces:
+                  - abc
+                  - xyz
+              excluded_check:
+                type: 'puppet-class-parameter'
+                settings:
+                  parameter: 'test_module_00::hard_excluded'
+                  value: 'should never appear'
+                controls:
+                  XY-n: true
+          A_YAML
+        },
+      }
+    end
+
+    subject(:compliance_engine) { described_class.new(*test_data.keys) }
+
+    before(:each) do
+      test_data.each do |module_path, file_data|
+        allow(File).to receive(:directory?).with(module_path).and_return(true)
+        allow(File).to receive(:directory?).with("#{module_path}/SIMP/compliance_profiles").and_return(true)
+        allow(File).to receive(:directory?).with("#{module_path}/simp/compliance_profiles").and_return(false)
+        allow(Dir).to receive(:glob)
+          .with("#{module_path}/SIMP/compliance_profiles/**/*.yaml")
+          .and_return(
+            file_data.map { |name, _contents| "#{module_path}/SIMP/compliance_profiles/#{name}" },
+          )
+        allow(Dir).to receive(:glob)
+          .with("#{module_path}/SIMP/compliance_profiles/**/*.json")
+          .and_return([])
+
+        file_data.each do |name, contents|
+          filename = "#{module_path}/SIMP/compliance_profiles/#{name}"
+          allow(File).to receive(:size).with(filename).and_return(contents.length)
+          allow(File).to receive(:mtime).with(filename).and_return(Time.now)
+          allow(File).to receive(:read).with(filename).and_return(contents)
+        end
+      end
+    end
+
+    it 'excludes a CE explicitly set to false even when the CE matches a positive control' do
+      checks = compliance_engine.check_mapping(compliance_engine.profiles['profile_with_excluded_ce'])
+      keys = checks.values.map(&:key)
+      expect(keys).not_to include('check_via_excluded_ce')
+      expect(keys).to include('check_via_other_ce')
+    end
+
+    it 'omits hiera data for checks reachable only via an excluded CE' do
+      hiera = compliance_engine.hiera(['profile_with_excluded_ce'])
+      expect(hiera).not_to have_key('test_module_00::via_excluded_ce')
+      expect(hiera).to include('test_module_00::via_other_ce' => 'should be included')
+    end
+
+    it 'still includes a check that has another non-excluded CE as a bridge' do
+      checks = compliance_engine.check_mapping(compliance_engine.profiles['profile_with_partial_ce_exclusion'])
+      keys = checks.values.map(&:key)
+      expect(keys).to include('check_via_two_ces')
+    end
+
+    it 'hard-excludes a check explicitly set to false even when other routes match' do
+      checks = compliance_engine.check_mapping(compliance_engine.profiles['profile_with_excluded_check'])
+      keys = checks.values.map(&:key)
+      expect(keys).not_to include('excluded_check')
+    end
+
+    it 'omits hiera data for a hard-excluded check' do
+      hiera = compliance_engine.hiera(['profile_with_excluded_check'])
+      expect(hiera).not_to have_key('test_module_00::hard_excluded')
+    end
+
+    it 'still includes unrelated checks when a different CE is excluded (regression guard)' do
+      excluded_keys = compliance_engine.check_mapping(compliance_engine.profiles['profile_with_excluded_ce']).values.map(&:key)
+      baseline_keys = compliance_engine.check_mapping(compliance_engine.profiles['profile_baseline']).values.map(&:key)
+      expect(excluded_keys).to include('check_via_other_ce')
+      expect(baseline_keys).to include('check_via_other_ce')
+    end
+  end
+
   context 'with zip data' do
     subject(:compliance_engine) { described_class.new }
 


### PR DESCRIPTION
A profile entry with value `false` now acts as an explicit exclusion that overrides positive mapping routes. This lets a profile author combine a positive control mapping with a negative CE override, e.g. `controls: { XY-n: true }` plus `ces: { abc: false }` to include everything mapped to control XY-n except CE abc.

- `Data#mapping?`: hard-exclude when `profile.checks[X] == false`; filter `profile.ces` by truthy value in the CE→Control bridge route; skip CEs that the profile explicitly excludes when traversing the reverse bridge through `check.ces`.
- `sce-schema.json`: document the false-as-exclusion semantic in titles for `controlsMap`, profile `ces`, and profile `checks`.
- `AGENTS.md`: note the new semantic in the check_mapping section.
- Add specs covering the user example, the route-F bridge case, the hard-exclude on `profile.checks`, and a regression guard against over-exclusion of unrelated checks.

Closes #117