### PR TITLE
fix: coerce non-String zipfile.name to '-' for buffer-opened zips

### DIFF
--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -128,10 +128,10 @@ class ComplianceEngine::Data
   # Scan a Puppet environment from a zip file
   # @param path [String] The Puppet environment archive file
   # @return [NilClass]
-  def open_environment_zip(path)
+  def open_environment_zip(path, name: nil)
     require 'compliance_engine/environment_loader/zip'
 
-    environment = ComplianceEngine::EnvironmentLoader::Zip.new(path)
+    environment = ComplianceEngine::EnvironmentLoader::Zip.new(path, name: name)
     self.modulepath = environment.modulepath
     open(environment)
   end

--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -126,7 +126,13 @@ class ComplianceEngine::Data
   end
 
   # Scan a Puppet environment from a zip file
-  # @param path [String] The Puppet environment archive file
+  # @param path [String, ::Zip::File] filesystem path to the zip archive, or
+  #   an already-opened ::Zip::File (e.g. from Zip::File.open_buffer); when a
+  #   ::Zip::File is passed, the caller owns its lifecycle
+  # @param name [String, nil] stable string identifier used as the modulepath
+  #   and cache-key prefix; defaults to the zip's filename on disk, or "-" for
+  #   buffer-opened zips.  Pass an explicit value when loading from a buffer to
+  #   keep cache keys unique and logs informative.
   # @return [NilClass]
   def open_environment_zip(path, name: nil)
     require 'compliance_engine/environment_loader/zip'

--- a/lib/compliance_engine/environment_loader/zip.rb
+++ b/lib/compliance_engine/environment_loader/zip.rb
@@ -21,7 +21,10 @@ class ComplianceEngine::EnvironmentLoader::Zip < ComplianceEngine::EnvironmentLo
   #   zip to keep cache keys unique and logs informative.
   def initialize(input, root: '/'.dup, load_dotfiles: true, name: nil)
     zipfile = input.is_a?(::Zip::File) ? input : ::Zip::File.open(input)
-    @modulepath = name || zipfile.name
+    # rubyzip 3.x returns the StringIO object from #name on buffer-opened zips;
+    # rubyzip 2.x returned "-".  Coerce any non-String to "-" so the key is
+    # always a stable string regardless of rubyzip version.
+    @modulepath = name || (zipfile.name.is_a?(String) ? zipfile.name : '-')
     super(root, fileclass: zipfile.file, dirclass: zipfile.dir, zipfile_path: @modulepath, load_dotfiles: load_dotfiles)
   ensure
     zipfile.close if zipfile && !input.is_a?(::Zip::File)

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1479,6 +1479,31 @@ RSpec.describe ComplianceEngine::Data do
     end
   end
 
+  context 'with a buffer-opened zip' do
+    subject(:compliance_engine) { described_class.new }
+
+    let(:zip_path) { File.expand_path('../../fixtures/test_environment.zip', __dir__) }
+    let(:bytes) { File.binread(zip_path) }
+
+    it 'loads CEs when no name: is given, defaulting modulepath to "-"' do
+      require 'zip'
+      Zip::File.open_buffer(bytes) do |zip|
+        compliance_engine.open_environment_zip(zip)
+        expect(compliance_engine.modulepath).to eq('-')
+        expect(compliance_engine.ces.keys).not_to be_empty
+      end
+    end
+
+    it 'loads CEs when name: is given' do
+      require 'zip'
+      Zip::File.open_buffer(bytes) do |zip|
+        compliance_engine.open_environment_zip(zip, name: 'buffer.zip')
+        expect(compliance_engine.modulepath).to eq('buffer.zip')
+        expect(compliance_engine.ces.keys).not_to be_empty
+      end
+    end
+  end
+
   context 'with multiple profiles and conflicting settings' do
     subject(:compliance_engine) { described_class.new(module_path) }
 

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -131,6 +131,32 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
     end
   end
 
+  context 'with a buffer-opened ::Zip::File' do
+    let(:path) { File.expand_path('../../../fixtures/test_environment.zip', __dir__) }
+    let(:bytes) { File.binread(path) }
+
+    before(:each) do
+      allow(ComplianceEngine::ModuleLoader).to receive(:new).and_return(instance_double(ComplianceEngine::ModuleLoader))
+    end
+
+    it 'defaults modulepath to "-" when no name: is given' do
+      Zip::File.open_buffer(bytes) do |zip|
+        env = described_class.new(zip)
+        expect(env.modulepath).to eq('-')
+        expect(env.modules.count).to eq(2)
+      end
+    end
+
+    it 'initializes and loads modules when name: is given' do
+      Zip::File.open_buffer(bytes) do |zip|
+        env = described_class.new(zip, name: 'buffer.zip')
+        expect(env).to be_instance_of(described_class)
+        expect(env.modulepath).to eq('buffer.zip')
+        expect(env.modules.count).to eq(2)
+      end
+    end
+  end
+
   context 'with a valid zip and an explicit name' do
     subject(:environment_loader) { described_class.new(path, name: name) }
 


### PR DESCRIPTION
rubyzip 3.x returns the underlying StringIO from Zip::File#name on buffer-opened zips rather than the string "-" rubyzip 2.x returned. EnvironmentLoader::Zip was using that value as the modulepath/cache-key prefix, so on rubyzip 3 all file keys became "#<StringIO:0x…>/./…", globbing matched nothing, and Data#ces/#profiles returned empty silently.

Coerce any non-String zipfile.name to "-" to restore rubyzip 2.x behaviour. Also thread name: through Data#open_environment_zip so callers loading from a buffer can supply a stable identifier without constructing the loader manually.

closes #120 