### PR TITLE
fix: replace Zip::File handoff with open_environment_zip_bytes

### DIFF
--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -128,7 +128,7 @@ class ComplianceEngine::Data
   # Scan a Puppet environment from a zip file on disk
   # @param path [String] filesystem path to the zip archive
   # @param name [String, nil] stable string identifier used as the modulepath
-  #   and cache-key prefix; defaults to the zip's filename on disk.
+  #   and cache-key prefix; defaults to the full path string passed as +path+.
   # @return [NilClass]
   def open_environment_zip(path, name: nil)
     require 'compliance_engine/environment_loader/zip'

--- a/lib/compliance_engine/data.rb
+++ b/lib/compliance_engine/data.rb
@@ -125,19 +125,29 @@ class ComplianceEngine::Data
     nil
   end
 
-  # Scan a Puppet environment from a zip file
-  # @param path [String, ::Zip::File] filesystem path to the zip archive, or
-  #   an already-opened ::Zip::File (e.g. from Zip::File.open_buffer); when a
-  #   ::Zip::File is passed, the caller owns its lifecycle
+  # Scan a Puppet environment from a zip file on disk
+  # @param path [String] filesystem path to the zip archive
   # @param name [String, nil] stable string identifier used as the modulepath
-  #   and cache-key prefix; defaults to the zip's filename on disk, or "-" for
-  #   buffer-opened zips.  Pass an explicit value when loading from a buffer to
-  #   keep cache keys unique and logs informative.
+  #   and cache-key prefix; defaults to the zip's filename on disk.
   # @return [NilClass]
   def open_environment_zip(path, name: nil)
     require 'compliance_engine/environment_loader/zip'
 
     environment = ComplianceEngine::EnvironmentLoader::Zip.new(path, name: name)
+    self.modulepath = environment.modulepath
+    open(environment)
+  end
+
+  # Scan a Puppet environment from a raw zip byte string
+  #
+  # @param bytes [String] raw binary zip data (e.g. from File.binread or an HTTP body)
+  # @param name [String, nil] stable string identifier used as the modulepath
+  #   and cache-key prefix; defaults to "-" when no filename is available.
+  # @return [NilClass]
+  def open_environment_zip_bytes(bytes, name: nil)
+    require 'compliance_engine/environment_loader/zip_bytes'
+
+    environment = ComplianceEngine::EnvironmentLoader::ZipBytes.new(bytes, name: name)
     self.modulepath = environment.modulepath
     open(environment)
   end

--- a/lib/compliance_engine/environment_loader/zip.rb
+++ b/lib/compliance_engine/environment_loader/zip.rb
@@ -7,26 +7,21 @@ require 'zip/filesystem'
 # Load compliance engine data from a zip file containing a Puppet environment
 class ComplianceEngine::EnvironmentLoader::Zip < ComplianceEngine::EnvironmentLoader
   # Initialize a ComplianceEngine::EnvironmentLoader::Zip object from a zip
-  # file and an optional root directory.
+  # file path and an optional root directory.
   #
-  # @param input [String, ::Zip::File] either a filesystem path to a zip file,
-  #   or an already-opened ::Zip::File (e.g. from Zip::File.open_buffer); when
-  #   a ::Zip::File is passed, the caller owns its lifecycle
+  # @param input [String] filesystem path to a zip file
   # @param root [String] a directory within the zip file to use as the root of the environment
   # @param load_dotfiles [Boolean] whether to load dotfiles; defaults to true to
   #   preserve the historical zip-loader behaviour of including all files
   # @param name [String, nil] identifier used for modulepath and downstream
-  #   cache keys; defaults to the zip's #name (the path on disk, or "-" for
-  #   buffer-opened zips). Pass an explicit value when loading a buffer-opened
-  #   zip to keep cache keys unique and logs informative.
+  #   cache keys; defaults to the zip path on disk.
   def initialize(input, root: '/'.dup, load_dotfiles: true, name: nil)
-    zipfile = input.is_a?(::Zip::File) ? input : ::Zip::File.open(input)
-    # rubyzip 3.x returns the StringIO object from #name on buffer-opened zips;
-    # rubyzip 2.x returned "-".  Coerce any non-String to "-" so the key is
-    # always a stable string regardless of rubyzip version.
-    @modulepath = name || (zipfile.name.is_a?(String) ? zipfile.name : '-')
+    raise ArgumentError, "input must be a String path, got #{input.class}" unless input.is_a?(String)
+
+    zipfile = ::Zip::File.open(input)
+    @modulepath = name || input.to_s
     super(root, fileclass: zipfile.file, dirclass: zipfile.dir, zipfile_path: @modulepath, load_dotfiles: load_dotfiles)
   ensure
-    zipfile.close if zipfile && !input.is_a?(::Zip::File)
+    zipfile&.close
   end
 end

--- a/lib/compliance_engine/environment_loader/zip.rb
+++ b/lib/compliance_engine/environment_loader/zip.rb
@@ -14,7 +14,7 @@ class ComplianceEngine::EnvironmentLoader::Zip < ComplianceEngine::EnvironmentLo
   # @param load_dotfiles [Boolean] whether to load dotfiles; defaults to true to
   #   preserve the historical zip-loader behaviour of including all files
   # @param name [String, nil] identifier used for modulepath and downstream
-  #   cache keys; defaults to the zip path on disk.
+  #   cache keys; defaults to the full path string passed as +input+.
   def initialize(input, root: '/'.dup, load_dotfiles: true, name: nil)
     raise ArgumentError, "input must be a String path, got #{input.class}" unless input.is_a?(String)
 

--- a/lib/compliance_engine/environment_loader/zip_bytes.rb
+++ b/lib/compliance_engine/environment_loader/zip_bytes.rb
@@ -16,6 +16,8 @@ class ComplianceEngine::EnvironmentLoader::ZipBytes < ComplianceEngine::Environm
   # @param name [String, nil] identifier used for modulepath and downstream
   #   cache keys; defaults to "-" when no filename is available.
   def initialize(bytes, root: '/'.dup, load_dotfiles: true, name: nil)
+    raise ArgumentError, "bytes must be a String, got #{bytes.class}" unless bytes.is_a?(String)
+
     zipfile = ::Zip::File.open_buffer(bytes)
     @modulepath = name || '-'
     super(root, fileclass: zipfile.file, dirclass: zipfile.dir, zipfile_path: @modulepath, load_dotfiles: load_dotfiles)

--- a/lib/compliance_engine/environment_loader/zip_bytes.rb
+++ b/lib/compliance_engine/environment_loader/zip_bytes.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../../compliance_engine'
+require_relative '../environment_loader'
+# zip/filesystem must be required before any Zip::File instance is opened so
+# that the per-instance dir/file accessors are wired up at open time.
+require 'zip/filesystem'
+require 'zip'
+
+# Load compliance engine data from a raw zip byte string containing a Puppet environment
+class ComplianceEngine::EnvironmentLoader::ZipBytes < ComplianceEngine::EnvironmentLoader
+  # @param bytes [String] raw binary zip data (e.g. from File.binread or an HTTP body)
+  # @param root [String] a directory within the zip file to use as the root of the environment
+  # @param load_dotfiles [Boolean] whether to load dotfiles; defaults to true to
+  #   preserve the historical zip-loader behaviour of including all files
+  # @param name [String, nil] identifier used for modulepath and downstream
+  #   cache keys; defaults to "-" when no filename is available.
+  def initialize(bytes, root: '/'.dup, load_dotfiles: true, name: nil)
+    zipfile = ::Zip::File.open_buffer(bytes)
+    @modulepath = name || '-'
+    super(root, fileclass: zipfile.file, dirclass: zipfile.dir, zipfile_path: @modulepath, load_dotfiles: load_dotfiles)
+  ensure
+    zipfile&.close
+  end
+end

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1538,7 +1538,7 @@ RSpec.describe ComplianceEngine::Data do
     it 'open_environment_zip rejects a pre-opened Zip::File' do
       require 'zip'
       Zip::File.open_buffer(bytes) do |zip|
-        expect { described_class.new.open_environment_zip(zip) }.to raise_error(ArgumentError, /must be a String path/)
+        expect { described_class.new.open_environment_zip(zip) }.to raise_error(ArgumentError, %r{must be a String path})
       end
     end
   end

--- a/spec/classes/compliance_engine/data_spec.rb
+++ b/spec/classes/compliance_engine/data_spec.rb
@@ -1479,27 +1479,66 @@ RSpec.describe ComplianceEngine::Data do
     end
   end
 
-  context 'with a buffer-opened zip' do
+  context 'with zip_bytes data' do
     subject(:compliance_engine) { described_class.new }
 
     let(:zip_path) { File.expand_path('../../fixtures/test_environment.zip', __dir__) }
     let(:bytes) { File.binread(zip_path) }
-
-    it 'loads CEs when no name: is given, defaulting modulepath to "-"' do
-      require 'zip'
-      Zip::File.open_buffer(bytes) do |zip|
-        compliance_engine.open_environment_zip(zip)
-        expect(compliance_engine.modulepath).to eq('-')
-        expect(compliance_engine.ces.keys).not_to be_empty
-      end
+    let(:test_files) do
+      [
+        'test_module_00/SIMP/compliance_profiles/a/file.yaml',
+        'test_module_00/SIMP/compliance_profiles/b/file.yaml',
+        'test_module_01/SIMP/compliance_profiles/c/file.yaml',
+      ]
     end
 
-    it 'loads CEs when name: is given' do
+    before(:each) do
+      compliance_engine.open_environment_zip_bytes(bytes)
+    end
+
+    it 'initializes' do
+      expect(compliance_engine).not_to be_nil
+      expect(compliance_engine).to be_instance_of(described_class)
+    end
+
+    it 'defaults modulepath to "-"' do
+      expect(compliance_engine.modulepath).to eq('-')
+    end
+
+    it 'returns a list of files' do
+      expect(compliance_engine.files).to eq(test_files.map { |file| File.join('-', '.', file) })
+    end
+
+    it 'returns a list of profiles' do
+      expect(compliance_engine.profiles).to be_instance_of(ComplianceEngine::Profiles)
+      expect(compliance_engine.profiles.keys).to eq(['test_profile_00', 'test_profile_01', 'test_profile_02'])
+    end
+
+    it 'returns a list of ces' do
+      expect(compliance_engine.ces).to be_instance_of(ComplianceEngine::Ces)
+      expect(compliance_engine.ces.keys).to eq(['ce_00', 'ce_01', 'ce_02', 'ce_03'])
+    end
+
+    it 'uses an explicit name as modulepath' do
+      engine = described_class.new
+      engine.open_environment_zip_bytes(bytes, name: 'buffer.zip')
+      expect(engine.modulepath).to eq('buffer.zip')
+      expect(engine.ces.keys).to eq(['ce_00', 'ce_01', 'ce_02', 'ce_03'])
+    end
+  end
+
+  # Regression lock: open_environment_zip previously accepted a pre-opened
+  # Zip::File, which allowed consumers to trigger a silent empty-load bug when
+  # the Zip::File was opened before zip/filesystem was required.  Ensure that
+  # path is permanently closed.
+  context 'regression: zip/filesystem require-order bug' do
+    let(:zip_path) { File.expand_path('../../fixtures/test_environment.zip', __dir__) }
+    let(:bytes) { File.binread(zip_path) }
+
+    it 'open_environment_zip rejects a pre-opened Zip::File' do
       require 'zip'
       Zip::File.open_buffer(bytes) do |zip|
-        compliance_engine.open_environment_zip(zip, name: 'buffer.zip')
-        expect(compliance_engine.modulepath).to eq('buffer.zip')
-        expect(compliance_engine.ces.keys).not_to be_empty
+        expect { described_class.new.open_environment_zip(zip) }.to raise_error(ArgumentError, /must be a String path/)
       end
     end
   end

--- a/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
@@ -2,37 +2,30 @@
 
 require 'spec_helper'
 require 'compliance_engine'
-require 'compliance_engine/environment_loader/zip'
+require 'compliance_engine/environment_loader/zip_bytes'
 
-RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
+RSpec.describe ComplianceEngine::EnvironmentLoader::ZipBytes do
   before(:each) do
     allow(Dir).to receive(:entries).and_call_original
   end
 
-  context 'with no paths' do
+  context 'with no arguments' do
     it 'does not initialize' do
       expect { described_class.new }.to raise_error(ArgumentError)
     end
   end
 
-  context 'with an invalid zip' do
-    subject(:environment_loader) { described_class.new(path) }
-
-    let(:path) { '/path/to/module.zip' }
-
-    before(:each) do
-      allow(Zip::File).to receive(:open).with(path).and_raise(Zip::Error)
-    end
-
+  context 'with invalid bytes' do
     it 'does not initialize' do
-      expect { described_class.new(path) }.to raise_error(Zip::Error)
+      expect { described_class.new('not a zip') }.to raise_error(Zip::Error)
     end
   end
 
-  context 'with a valid zip' do
-    subject(:environment_loader) { described_class.new(path) }
+  context 'with valid bytes' do
+    subject(:environment_loader) { described_class.new(bytes) }
 
     let(:path) { File.expand_path('../../../fixtures/test_environment.zip', __dir__) }
+    let(:bytes) { File.binread(path) }
 
     before(:each) do
       allow(ComplianceEngine::ModuleLoader).to receive(:new).and_return(instance_double(ComplianceEngine::ModuleLoader))
@@ -45,17 +38,20 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
     it 'is not empty' do
       expect(environment_loader.modules).to be_instance_of(Array)
       expect(environment_loader.modules.count).to eq(2)
-      expect(environment_loader.modulepath).to eq(path)
     end
 
-    it 'sets zipfile_path to the path' do
-      expect(environment_loader.zipfile_path).to eq(path)
+    it 'defaults modulepath to "-"' do
+      expect(environment_loader.modulepath).to eq('-')
+    end
+
+    it 'sets zipfile_path to "-"' do
+      expect(environment_loader.zipfile_path).to eq('-')
     end
 
     it 'closes the zip after initialization' do
       close_called = false
-      allow(Zip::File).to receive(:open).and_wrap_original do |original, p|
-        zip = original.call(p)
+      allow(Zip::File).to receive(:open_buffer).and_wrap_original do |original, b|
+        zip = original.call(b)
         allow(zip).to(receive(:close).and_wrap_original do |m, *args|
           close_called = true
           m.call(*args)
@@ -72,30 +68,16 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
     end
 
     it 'passes load_dotfiles: false to ModuleLoader when requested' do
-      described_class.new(path, load_dotfiles: false)
+      described_class.new(bytes, load_dotfiles: false)
       expect(ComplianceEngine::ModuleLoader).to have_received(:new).with(anything, hash_including(load_dotfiles: false)).at_least(:once)
     end
   end
 
-  context 'with a non-String input' do
-    it 'raises ArgumentError for a Zip::File object' do
-      require 'zip'
-      path = File.expand_path('../../../fixtures/test_environment.zip', __dir__)
-      Zip::File.open(path) do |zipfile|
-        expect { described_class.new(zipfile) }.to raise_error(ArgumentError, /must be a String path/)
-      end
-    end
-
-    it 'raises ArgumentError for any non-String' do
-      expect { described_class.new(42) }.to raise_error(ArgumentError, /must be a String path/)
-      expect { described_class.new(nil) }.to raise_error(ArgumentError, /must be a String path/)
-    end
-  end
-
-  context 'with a valid zip and an explicit name' do
-    subject(:environment_loader) { described_class.new(path, name: name) }
+  context 'with valid bytes and an explicit name' do
+    subject(:environment_loader) { described_class.new(bytes, name: name) }
 
     let(:path) { File.expand_path('../../../fixtures/test_environment.zip', __dir__) }
+    let(:bytes) { File.binread(path) }
     let(:name) { 'custom_name.zip' }
 
     before(:each) do
@@ -107,5 +89,4 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       expect(environment_loader.zipfile_path).to eq(name)
     end
   end
-
 end

--- a/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::ZipBytes do
 
   context 'with a non-String input' do
     it 'raises ArgumentError for any non-String' do
-      expect { described_class.new(42) }.to raise_error(ArgumentError, /must be a String/)
-      expect { described_class.new(nil) }.to raise_error(ArgumentError, /must be a String/)
+      expect { described_class.new(42) }.to raise_error(ArgumentError, %r{must be a String})
+      expect { described_class.new(nil) }.to raise_error(ArgumentError, %r{must be a String})
     end
   end
 

--- a/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::ZipBytes do
     end
   end
 
+  context 'with a non-String input' do
+    it 'raises ArgumentError for any non-String' do
+      expect { described_class.new(42) }.to raise_error(ArgumentError, /must be a String/)
+      expect { described_class.new(nil) }.to raise_error(ArgumentError, /must be a String/)
+    end
+  end
+
   context 'with invalid bytes' do
     it 'does not initialize' do
       expect { described_class.new('not a zip') }.to raise_error(Zip::Error)

--- a/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_bytes_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::ZipBytes do
       close_called = false
       allow(Zip::File).to receive(:open_buffer).and_wrap_original do |original, b|
         zip = original.call(b)
-        allow(zip).to(receive(:close).and_wrap_original do |m, *args|
+        allow(zip).to receive(:close).and_wrap_original do |m, *args|
           close_called = true
           m.call(*args)
-        end)
+        end
         zip
       end
       environment_loader

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       require 'zip'
       path = File.expand_path('../../../fixtures/test_environment.zip', __dir__)
       Zip::File.open(path) do |zipfile|
-        expect { described_class.new(zipfile) }.to raise_error(ArgumentError, /must be a String path/)
+        expect { described_class.new(zipfile) }.to raise_error(ArgumentError, %r{must be a String path})
       end
     end
 
     it 'raises ArgumentError for any non-String' do
-      expect { described_class.new(42) }.to raise_error(ArgumentError, /must be a String path/)
-      expect { described_class.new(nil) }.to raise_error(ArgumentError, /must be a String path/)
+      expect { described_class.new(42) }.to raise_error(ArgumentError, %r{must be a String path})
+      expect { described_class.new(nil) }.to raise_error(ArgumentError, %r{must be a String path})
     end
   end
 
@@ -107,5 +107,4 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       expect(environment_loader.zipfile_path).to eq(name)
     end
   end
-
 end

--- a/spec/classes/compliance_engine/environment_loader/zip_spec.rb
+++ b/spec/classes/compliance_engine/environment_loader/zip_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe ComplianceEngine::EnvironmentLoader::Zip do
       close_called = false
       allow(Zip::File).to receive(:open).and_wrap_original do |original, p|
         zip = original.call(p)
-        allow(zip).to(receive(:close).and_wrap_original do |m, *args|
+        allow(zip).to receive(:close).and_wrap_original do |m, *args|
           close_called = true
           m.call(*args)
-        end)
+        end
         zip
       end
       environment_loader


### PR DESCRIPTION
The Zip::File-handoff form added in 86cbda1 had a silent load-order trap: if the caller opened a Zip::File.open_buffer before zip/filesystem was required, the per-instance dir/file accessors were never initialized (nil).  EnvironmentLoader silently rescued the resulting NoMethodError and returned an empty module list — 0 files, 0 CEs, 0 profiles, no error raised.  The require order was impossible to discover from the API surface and could not be enforced from inside the gem once the caller already held the open instance.

Fix: remove the Zip::File input path entirely and replace it with a dedicated method and loader class that own the zip lifecycle.

- Revert EnvironmentLoader::Zip to accept only a String path.  Add an explicit ArgumentError guard so passing a Zip::File (or any non-String) now fails loudly instead of silently.
- Add EnvironmentLoader::ZipBytes: a new loader class that accepts raw bytes, requires zip/filesystem before calling Zip::File.open_buffer, and closes the zip in ensure after all file content has been read eagerly — matching the lifecycle pattern of EnvironmentLoader::Zip.
- Add Data#open_environment_zip_bytes(bytes, name: nil): mirrors open_environment_zip in structure; delegates to ZipBytes so callers never interact with rubyzip directly.
- Remove spec coverage for the Zip::File input branches; add zip_bytes_spec.rb covering the new class (no-args, invalid bytes, valid bytes, explicit name, zip closed after init, dotfiles flag).
- Add a 'with zip_bytes data' context in data_spec with the same exact-content assertions as 'with zip data' (files, profiles, CEs, explicit name).
- Retain a single regression lock: open_environment_zip raises ArgumentError when given a pre-opened Zip::File, ensuring the broken Zip::File-handoff path cannot be quietly re-introduced.