### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,10 @@ paths → EnvironmentLoader → ModuleLoader (one per module dir)
 
 In practice, only fact confinement is bypassed when `facts` is `nil`; module confinement still applies whenever `environment_data` is available. All confinement and risk/disabled-remediation filtering are effectively bypassed only when both `facts` and `environment_data` are unset and `enforcement_tolerance` is not a positive `Integer` (every fragment is then included). This is useful for offline analysis where system context and enforcement settings are unavailable.
 
+### Releases
+
+Keep the version in `lib/compliance_engine/version.rb` (`ComplianceEngine::VERSION`) and the `version` field in `metadata.json` in sync — they must always match. Any version bump must also be accompanied by a corresponding entry in `CHANGELOG.md`.
+
 ### Code Style
 
 Rubocop is configured via `.rubocop.yml` inheriting from `voxpupuli-test`. Key style choices:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.0 / 2026-06-04
+* Declare the gem and Puppet module production-ready; no functional changes since 0.6.0
+
 ### 0.6.0 / 2026-05-05
 * Honor explicit `false` in profile `checks` and `ces` mappings as exclusions that override positive matches (#117)
 * Coerce non-String `zipfile.name` to `-` for buffer-opened zips (#121)

--- a/lib/compliance_engine/version.rb
+++ b/lib/compliance_engine/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ComplianceEngine
-  VERSION = '0.6.0'
+  VERSION = '1.0.0'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_engine",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "author": "Sicura",
   "summary": "Hiera backend for Sicura Compliance Engine data",
   "license": "Apache-2.0",


### PR DESCRIPTION
Declares the gem and Puppet module production-ready. No functional changes since 0.6.0. Also adds a Releases note to AGENTS.md requiring version.rb and metadata.json to stay in sync and any version bump to include a CHANGELOG.md entry.