### PR TITLE
Include Enumerable in Collection (#each_with_object etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Unreleased
-* Include `Enumerable` in `ComplianceEngine::Collection` so all collections (`Ces`, `Checks`, `Controls`, `Profiles`) gain the full Enumerable interface (`#each_with_object`, `#map`, `#reduce`, `#find`, ...); they defined `#each` but raised `NoMethodError` on these. The explicit `#select`/`#reject`/`#keys` still return Collections. (#127)
+* Include `Enumerable` in `ComplianceEngine::Collection` so all collections (`Ces`, `Checks`, `Controls`, `Profiles`) gain the full Enumerable interface (`#each_with_object`, `#map`, `#reduce`, `#find`, ...); they defined `#each` but raised `NoMethodError` on these. The explicit `#select`/`#reject` still return Collections. (#127)
 
 ### 1.0.0 / 2026-06-04
 * Declare the gem and Puppet module production-ready; no functional changes since 0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Include `Enumerable` in `ComplianceEngine::Collection` so all collections (`Ces`, `Checks`, `Controls`, `Profiles`) gain the full Enumerable interface (`#each_with_object`, `#map`, `#reduce`, `#find`, ...); they defined `#each` but raised `NoMethodError` on these. The explicit `#select`/`#reject`/`#keys` still return Collections. (#127)
+
 ### 1.0.0 / 2026-06-04
 * Declare the gem and Puppet module production-ready; no functional changes since 0.6.0
 

--- a/lib/compliance_engine/collection.rb
+++ b/lib/compliance_engine/collection.rb
@@ -6,9 +6,9 @@ require_relative '../compliance_engine'
 class ComplianceEngine::Collection
   # Collections define #each (yielding [name, component] pairs), so mixing in
   # Enumerable gives them the full collection interface: #each_with_object,
-  # #map, #reduce, #find, #count, etc. The hash-like methods this class defines
-  # explicitly (#select, #reject, #keys) shadow Enumerable's, so they keep
-  # returning Collections rather than Arrays. See #37.
+  # #map, #reduce, #find, #count, etc. The #select/#reject defined explicitly on
+  # this class shadow Enumerable's, so they keep returning Collections rather
+  # than Arrays. See #37.
   include Enumerable
 
   # A generic compliance engine data collection

--- a/lib/compliance_engine/collection.rb
+++ b/lib/compliance_engine/collection.rb
@@ -4,6 +4,13 @@ require_relative '../compliance_engine'
 
 # A generic compliance engine data collection
 class ComplianceEngine::Collection
+  # Collections define #each (yielding [name, component] pairs), so mixing in
+  # Enumerable gives them the full collection interface: #each_with_object,
+  # #map, #reduce, #find, #count, etc. The hash-like methods this class defines
+  # explicitly (#select, #reject, #keys) shadow Enumerable's, so they keep
+  # returning Collections rather than Arrays. See #37.
+  include Enumerable
+
   # A generic compliance engine data collection
   #
   # @param data [ComplianceEngine::Data] the data to initialize the object with

--- a/spec/classes/compliance_engine/ces_spec.rb
+++ b/spec/classes/compliance_engine/ces_spec.rb
@@ -77,6 +77,47 @@ RSpec.describe ComplianceEngine::Ces do
   end
 
   # ---------------------------------------------------------------------------
+  # Enumerable interface: Collection defines #each, so it mixes in Enumerable
+  # ---------------------------------------------------------------------------
+  describe 'Enumerable interface' do
+    subject(:ces) { described_class.new(ComplianceEngine::Data.new(ComplianceEngine::DataLoader.new(compliance_data))) }
+
+    let(:compliance_data) do
+      {
+        'version' => '2.0.0',
+        'ce' => {
+          'ce_one' => { 'title' => 'CE One' },
+          'ce_two' => { 'title' => 'CE Two' },
+        },
+      }
+    end
+
+    it 'is Enumerable' do
+      expect(ces).to be_a(Enumerable)
+    end
+
+    # Regression: Ces defined #each but did not include Enumerable, so
+    # #each_with_object (and the rest of Enumerable) raised NoMethodError.
+    it 'supports #each_with_object over [name, component] pairs' do
+      index = ces.each_with_object({}) { |(name, ce), acc| acc[ce.title] = name }
+      expect(index).to eq('CE One' => 'ce_one', 'CE Two' => 'ce_two')
+    end
+
+    it 'supports #map and #find' do
+      expect(ces.map { |name, _ce| name }).to contain_exactly('ce_one', 'ce_two')
+      _name, ce = ces.find { |name, _ce| name == 'ce_two' }
+      expect(ce.title).to eq('CE Two')
+    end
+
+    # The explicit #select/#reject must keep shadowing Enumerable's, so they
+    # still return Collections rather than Arrays of pairs.
+    it 'keeps Collection-returning #select/#reject' do
+      expect(ces.select { |k, _| k == 'ce_one' }).to be_instance_of(described_class) # rubocop:disable Style/HashSlice
+      expect(ces.reject { |k, _| k == 'ce_one' }).to be_instance_of(described_class)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # clone/dup isolation (Collection behavior)
   #
   # Ces is used as the concrete Collection subclass.  Source has all Ce caches


### PR DESCRIPTION
## Problem

`ComplianceEngine::Collection` (and subclasses `Ces`, `Checks`, `Controls`, `Profiles`) define `#each` but do not `include Enumerable`, so the standard Enumerable methods raise on every collection:

```ruby
ces.each_with_object({}) { |(name, ce), acc| ... }
# => NoMethodError: undefined method 'each_with_object' for an instance of ComplianceEngine::Ces
```

A downstream consumer building an OVAL-id → CE reverse index with `ces.each_with_object({})` crashed on this — the object walks like an enumerable (`#each`, `#to_h`, `#select`, `#reject`) but isn't one. See #127.

## Fix

`include Enumerable` in `ComplianceEngine::Collection`. Because the class defines `#each` (yielding `[name, component]` pairs via `to_h.each`), this fills in `#each_with_object`, `#map`, `#reduce`, `#find`, `#count`, etc. for all collection types.

The explicit hash-like methods (`#select`, `#reject`, `#keys`) are defined on the class, so they **shadow** Enumerable's and keep returning Collections rather than Arrays (the behavior from #37) — verified by a test.

## Tests

`spec/classes/compliance_engine/ces_spec.rb` gains an `Enumerable interface` group:
- `each_with_object` over `[name, component]` pairs (the regression),
- `#map` / `#find`,
- `#select` / `#reject` still return Collections (no regression from the mixin).

`bundle exec rspec spec/classes/compliance_engine/{ces,collection,checks,controls,component,ce}_spec.rb` → **50 examples, 0 failures**; RuboCop clean.

Fixes #127