### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased
+### 1.1.0 / 2026-06-11
 * Include `Enumerable` in `ComplianceEngine::Collection` so all collections (`Ces`, `Checks`, `Controls`, `Profiles`) gain the full Enumerable interface (`#each_with_object`, `#map`, `#reduce`, `#find`, ...); they defined `#each` but raised `NoMethodError` on these. The explicit `#select`/`#reject` still return Collections. (#127)
 
 ### 1.0.0 / 2026-06-04

--- a/lib/compliance_engine/version.rb
+++ b/lib/compliance_engine/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ComplianceEngine
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_engine",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Sicura",
   "summary": "Hiera backend for Sicura Compliance Engine data",
   "license": "Apache-2.0",


### PR DESCRIPTION
Promotes the Unreleased CHANGELOG entry for PR #127 (Enumerable in Collection) to the 1.1.0 release. Minor bump because the change adds the full Enumerable interface to collections — additive and backward-compatible.